### PR TITLE
[S1/F0] Frontend TS models for cross-location picking + lots + reserved qty

### DIFF
--- a/src/app/models/index.ts
+++ b/src/app/models/index.ts
@@ -72,6 +72,7 @@ export interface AuthState {
 
 // Re-export auth models
 export * from './auth.model';
+export * from './lot-entry.model';
 export * from './inventory.model';
 export * from './article.model';
 export * from './dashboard.model';

--- a/src/app/models/inventory.model.ts
+++ b/src/app/models/inventory.model.ts
@@ -18,6 +18,8 @@ export interface Inventory {
 	max_quantity?: number | null;
 	lots?: Lot[] | null;
 	serials?: Serial[] | null;
+	reserved_qty?: number;     // cantidad reservada por pickings in_progress
+	available_qty?: number;    // quantity - reserved_qty (calculado backend)
 }
 
 export interface CreateInventoryRequest {

--- a/src/app/models/lot-entry.model.ts
+++ b/src/app/models/lot-entry.model.ts
@@ -1,0 +1,25 @@
+export interface LotEntry {
+  lot_number: string;
+  sku?: string;
+  quantity: number;
+  expiration_date?: string;   // "YYYY-MM-DD"
+  manufactured_date?: string; // "YYYY-MM-DD" — para S2
+  status?: 'pending' | 'picked' | 'received' | 'skipped' | string;
+}
+
+/**
+ * A1: un ítem de picking se puede distribuir entre varias ubicaciones.
+ * Ejemplo: pick 100 uds → 60 del estante-A + 40 del estante-B.
+ *
+ * expiration_date viene populada desde el endpoint de pick-suggestions
+ * para evitar que el frontend haga queries extra por cada lote.
+ * El campo es display-only — el backend no lo persiste en picking_tasks.
+ */
+export interface LocationAllocation {
+  location: string;
+  quantity: number;
+  lot_number?: string;
+  picked_qty?: number;
+  status?: 'pending' | 'picked' | 'skipped' | string;
+  expiration_date?: string;  // "YYYY-MM-DD" — display only (del pick-suggestions response)
+}

--- a/src/app/models/picking-task.model.ts
+++ b/src/app/models/picking-task.model.ts
@@ -1,3 +1,14 @@
+import { LotEntry, LocationAllocation } from './lot-entry.model';
+
+export type PickingTaskStatus =
+  | 'open'
+  | 'in_progress'
+  | 'assigned'
+  | 'completed'
+  | 'completed_with_differences'
+  | 'cancelled'
+  | 'abandoned';
+
 export interface PickingTask {
 	id: string;
 	task_id: string;
@@ -5,7 +16,7 @@ export interface PickingTask {
 	order_number?: string; // Campo del backend
 	created_by: string;
 	assigned_to: string;
-	status: string;
+	status: PickingTaskStatus | string;
 	priority: string;
 	notes?: string | null;
 	items: PickingTaskItem[];
@@ -16,14 +27,18 @@ export interface PickingTask {
 
 export interface PickingTaskItem {
 	sku: string;
-	required_qty?: number; // Para compatibilidad con frontend
-	expectedQty?: number; // Campo del backend
+	required_qty: number;               // A1: requerido
 	picked_qty?: number;
-	location: string;
-	lot_numbers?: string[]; // Para compatibilidad con frontend
-	serial_numbers?: string[]; // Para compatibilidad con frontend
-	lotNumbers?: string[] | null; // Campo del backend
-	serialNumbers?: string[] | null; // Campo del backend
+	status?: string;
+	allocations: LocationAllocation[];  // A1: reemplaza location: string
+	lots?: LotEntry[];                  // lotes asignados al ítem (agregados across allocations)
+	serial_numbers?: string[];
+	// Aliases legacy (solo para leer tareas viejas del backend — Wave 7/F2 los elimina):
+	location?: string;          // antes era el campo principal; ahora es fallback de lectura
+	expectedQty?: number;
+	lot_numbers?: string[];
+	lotNumbers?: string[] | null;
+	serialNumbers?: string[] | null;
 }
 
 export interface CreatePickingTaskRequest {
@@ -38,8 +53,8 @@ export interface CreatePickingTaskRequest {
 export interface CreatePickingTaskItemRequest {
 	sku: string;
 	required_qty: number;
-	location: string;
-	lot_numbers?: string[];
+	allocations: LocationAllocation[];  // requerido: al menos una allocation
+	lots?: LotEntry[];
 	serial_numbers?: string[];
 }
 

--- a/src/app/models/receiving-task.model.ts
+++ b/src/app/models/receiving-task.model.ts
@@ -1,11 +1,20 @@
+import { LotEntry } from './lot-entry.model';
+
+export type ReceivingTaskStatus =
+  | 'open'
+  | 'in_progress'
+  | 'completed'
+  | 'completed_with_differences'
+  | 'cancelled';
+
 export interface ReceivingTask {
 	id: number;
 	task_id: string;
 	inbound_number: string;
-	order_number?: string; 
+	order_number?: string;
 	created_by: string;
 	assigned_to: string;
-	status: string;
+	status: ReceivingTaskStatus | string;
 	priority: string;
 	notes?: string | null;
 	items: ReceivingTaskItem[];
@@ -17,20 +26,23 @@ export interface ReceivingTask {
 export interface ReceivingTaskItem {
 	sku: string;
 	expected_qty: number;
-	expectedQty?: number; 
+	expectedQty?: number;
 	received_qty: number;
-	location: string;
-	lot_numbers?: string[];
+	location: string;           // receiving es single-location por línea
+	status?: string;
+	lots?: LotEntry[];          // shape nuevo (Wave 6+)
 	serial_numbers?: string[];
-	lotNumbers?: string[]; 
-	serialNumbers?: string[]; 
+	// Aliases legacy (solo para leer tareas viejas del backend):
+	lot_numbers?: string[];
+	lotNumbers?: string[];
+	serialNumbers?: string[];
 }
 
 export interface CreateReceivingTaskRequest {
 	inbound_number: string;
 	assigned_to: string;
 	priority: string;
-	status: string; 
+	status: string;
 	notes?: string;
 	items: CreateReceivingTaskItemRequest[];
 }
@@ -39,7 +51,7 @@ export interface CreateReceivingTaskItemRequest {
 	sku: string;
 	expected_qty: number;
 	location: string;
-	lot_numbers?: string[];
+	lots?: LotEntry[];
 	serial_numbers?: string[];
 }
 


### PR DESCRIPTION
## Summary

- **New** `lot-entry.model.ts`: `LotEntry` + `LocationAllocation` interfaces (A1, Wave 6)
- **Updated** `receiving-task.model.ts`: `lots?: LotEntry[]` replaces `lot_numbers?`; legacy `lot_numbers`/`lotNumbers` aliases kept for backward-compat reading; `ReceivingTaskStatus` union type
- **Updated** `picking-task.model.ts`: `allocations: LocationAllocation[]` + `lots?: LotEntry[]` + `required_qty: number`; legacy `location?`/`lotNumbers` aliases for Wave 7 components; `PickingTaskStatus` union type
- **Updated** `inventory.model.ts`: `reserved_qty?` + `available_qty?` (B2b backend fields)
- **Updated** `index.ts`: re-exports `lot-entry.model`

## Downstream TS errors (Wave 7 — NOT fixed here)

| File | Line | Error | Wave |
|------|------|-------|------|
| `picking-task-form.component.ts` | 264 | `string \| undefined` not assignable to `string` (`item.location` now optional) | F2 |

`receiving-task-form.component.ts` and `picking-task-details-content.component.ts` compile cleanly with legacy aliases in place.

## Test plan

- [ ] `npx ng build` passes with 0 TS errors in model files
- [ ] 1 remaining error is confirmed in `picking-task-form.component.ts:264` (Wave 7/F2 scope)
- [ ] F1 (receiving sub-form lotes) can now import `LotEntry` from `./lot-entry.model`
- [ ] F2 (picking cross-location form) can now import `LocationAllocation` from `./lot-entry.model`

Ver plans/sessions/2026-04-15-block-F0.md