### PR TITLE
[S1/F2+F3] Picking form cross-location + available qty + start lazy reservation

### DIFF
--- a/src/app/components/picking-tasks/picking-task-form/picking-task-form.component.html
+++ b/src/app/components/picking-tasks/picking-task-form/picking-task-form.component.html
@@ -10,7 +10,7 @@
             {{ isEditing ? t('edit_picking_task_description') : t('create_picking_task_description') }}
           </p>
         </div>
-        <button type="button" (click)="close()" class="text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground p-1 flex-shrink-0" aria-label="Close">
+        <button type="button" (click)="close()" class="text-muted-foreground hover:text-muted-foreground p-1 flex-shrink-0" aria-label="Close">
           <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
           </svg>
@@ -21,452 +21,318 @@
 
   <div drawerContent class="px-1">
     <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-6 max-h-[70vh] overflow-y-auto">
-          <!-- Task Header Information -->
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <!-- Outbound Number -->
-            <div class="form-group min-w-0">
-              <label class="block text-sm font-medium text-muted-foreground mb-1.5">
-                {{ t('outbound_number') }}
-              </label>
-              <input type="text" formControlName="outbound_number" [placeholder]="t('outbound_number_placeholder_short')"
-                class="w-full min-w-0 h-10 min-h-10 px-3 py-2 border border-border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground"
-                [class.border-red-500]="isFieldInvalid('outbound_number')"
-                [class.focus:ring-red-500]="isFieldInvalid('outbound_number')"
-                [class.focus:border-red-500]="isFieldInvalid('outbound_number')" />
-              <div *ngIf="isFieldInvalid('outbound_number')" class="text-red-600 text-sm mt-1">
-                {{ getFieldError('outbound_number') }}
-              </div>
-            </div>
 
-            <!-- Assigned To -->
-            <div class="form-group relative min-w-0">
-              <label class="block text-sm font-medium text-muted-foreground mb-1.5">
-                {{ t('assign_to_operator') }} <span class="text-red-500">*</span>
-              </label>
-              <div class="relative">
-                <input type="text" 
-                  (focus)="showOperatorDropdown = true" 
-                  (blur)="onOperatorBlur()"
-                  [(ngModel)]="operatorSearchTerm" 
-                  (input)="filterOperators()"
-                  (keydown.enter)="$event.preventDefault(); confirmFirstOperatorIfAny()" 
-                  [ngModelOptions]="{standalone: true}"
-                  placeholder="{{ t('select_operator_short') }}"
-                  class="block w-full min-w-0 h-10 min-h-10 px-3 py-2 pr-16 border rounded-lg border-border shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground"
-                  [class.border-red-500]="isFieldInvalid('assigned_to') || (operatorSearchTerm && !isOperatorValid())"
-                  [class.border-green-500]="operatorSearchTerm && isOperatorValid() && !isFieldInvalid('assigned_to')"
-                  [class.focus:ring-red-500]="isFieldInvalid('assigned_to') || (operatorSearchTerm && !isOperatorValid())"
-                  [class.focus:border-red-500]="isFieldInvalid('assigned_to') || (operatorSearchTerm && !isOperatorValid())"
-                  [class.focus:ring-green-500]="operatorSearchTerm && isOperatorValid() && !isFieldInvalid('assigned_to')"
-                  [class.focus:border-green-500]="operatorSearchTerm && isOperatorValid() && !isFieldInvalid('assigned_to')"
-                  [class.border-border]="!isFieldInvalid('assigned_to') && (!operatorSearchTerm || isOperatorValid())"
-                />
-                <input type="hidden" formControlName="assigned_to" />
-                
-                <!-- Botones de acción -->
-                <div class="absolute inset-y-0 right-0 flex items-center pr-2 space-x-1">
-                  <!-- Botón de editar (cuando hay selección válida) -->
-                  <button type="button" 
-                    *ngIf="hasValidOperatorSelection()"
-                    (click)="enableOperatorEdit()"
-                    class="p-1 text-muted-foreground hover:text-blue-600 focus:outline-none focus:text-blue-600"
-                    [title]="t('edit_selection')">
-                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
-                    </svg>
-                  </button>
-                  
-                  <!-- Botón de limpiar -->
-                  <button type="button" 
-                    *ngIf="operatorSearchTerm || hasValidOperatorSelection()"
-                    (click)="clearOperatorManually()"
-                    class="p-1 text-muted-foreground hover:text-red-600 focus:outline-none focus:text-red-600"
-                    [title]="t('clear_selection')">
-                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div *ngIf="showOperatorDropdown" class="absolute z-10 mt-1 w-full bg-background border border-border rounded-md max-h-56 overflow-auto shadow-lg">
-                <button type="button" *ngFor="let user of filteredOperators" (mousedown)="$event.preventDefault()" (click)="onOperatorSelected(user)"
-                  class="w-full text-left px-3 py-2 hover:bg-muted text-sm text-muted-foreground">
-                  {{ getUserDisplayName(user.id) }}
-                </button>
-                <div *ngIf="filteredOperators.length === 0" class="px-3 py-2 text-sm text-muted-foreground">
-                  {{ t('no_results') }}
-                </div>
-              </div>
-              <p *ngIf="isFieldInvalid('assigned_to')" class="mt-1 text-sm text-red-600">
-                {{ getFieldError('assigned_to') }}
-              </p>
-              <p *ngIf="!isFieldInvalid('assigned_to') && operatorSearchTerm && !isOperatorValid()" class="mt-1 text-sm text-amber-600">
-                ⚠ {{ t('type_to_search_or_select') }}
-              </p>
-              <p *ngIf="hasValidOperatorSelection()" class="mt-1 text-sm text-green-600">
-                ✓ {{ getSelectedOperatorName() }} - {{ t('selected') }}
-              </p>
-            </div>
+      <!-- ── Task Header ─────────────────────────────────────── -->
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
 
-            <!-- Priority -->
-            <div class="form-group min-w-0">
-              <label class="block text-sm font-medium text-muted-foreground mb-2">
-                {{ t('priority') }}
-              </label>
-              <z-select formControlName="priority" zSize="lg" class="w-full">
-                <z-select-item zValue="normal">{{ t('normal') }}</z-select-item>
-                <z-select-item zValue="high">{{ t('high') }}</z-select-item>
-                <z-select-item zValue="urgent">{{ t('urgent') }}</z-select-item>
-              </z-select>
+        <!-- Outbound Number -->
+        <div class="form-group min-w-0">
+          <label class="block text-sm font-medium text-muted-foreground mb-1.5">
+            {{ t('outbound_number') }}
+          </label>
+          <input type="text" formControlName="outbound_number"
+            [placeholder]="t('outbound_number_placeholder_short')"
+            class="w-full min-w-0 h-10 min-h-10 px-3 py-2 border border-border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground"
+            [class.border-red-500]="isFieldInvalid('outbound_number')" />
+          <div *ngIf="isFieldInvalid('outbound_number')" class="text-red-600 text-sm mt-1">
+            {{ getFieldError('outbound_number') }}
+          </div>
+        </div>
+
+        <!-- Assigned To (operator combobox) -->
+        <div class="form-group relative min-w-0">
+          <label class="block text-sm font-medium text-muted-foreground mb-1.5">
+            {{ t('assign_to_operator') }} <span class="text-red-500">*</span>
+          </label>
+          <div class="relative">
+            <input type="text"
+              (focus)="showOperatorDropdown = true"
+              (blur)="onOperatorBlur()"
+              [(ngModel)]="operatorSearchTerm"
+              (input)="filterOperators()"
+              (keydown.enter)="$event.preventDefault(); confirmFirstOperatorIfAny()"
+              [ngModelOptions]="{standalone: true}"
+              placeholder="{{ t('select_operator_short') }}"
+              class="block w-full min-w-0 h-10 min-h-10 px-3 py-2 pr-16 border rounded-lg border-border shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground"
+              [class.border-red-500]="isFieldInvalid('assigned_to') || (operatorSearchTerm && !isOperatorValid())"
+              [class.border-green-500]="operatorSearchTerm && isOperatorValid() && !isFieldInvalid('assigned_to')" />
+            <input type="hidden" formControlName="assigned_to" />
+            <div class="absolute inset-y-0 right-0 flex items-center pr-2 space-x-1">
+              <button type="button" *ngIf="hasValidOperatorSelection()" (click)="enableOperatorEdit()"
+                class="p-1 text-muted-foreground hover:text-blue-600" [title]="t('edit_selection')">
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                </svg>
+              </button>
+              <button type="button" *ngIf="operatorSearchTerm || hasValidOperatorSelection()" (click)="clearOperatorManually()"
+                class="p-1 text-muted-foreground hover:text-red-600" [title]="t('clear_selection')">
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+              </button>
             </div>
           </div>
+          <div *ngIf="showOperatorDropdown" class="absolute z-10 mt-1 w-full bg-background border border-border rounded-md max-h-56 overflow-auto shadow-lg">
+            <button type="button" *ngFor="let user of filteredOperators" (mousedown)="$event.preventDefault()" (click)="onOperatorSelected(user)"
+              class="w-full text-left px-3 py-2 hover:bg-muted text-sm text-muted-foreground">
+              {{ getUserDisplayName(user.id) }}
+            </button>
+            <div *ngIf="filteredOperators.length === 0" class="px-3 py-2 text-sm text-muted-foreground">
+              {{ t('no_results') }}
+            </div>
+          </div>
+          <p *ngIf="isFieldInvalid('assigned_to')" class="mt-1 text-sm text-red-600">
+            {{ getFieldError('assigned_to') }}
+          </p>
+          <p *ngIf="!isFieldInvalid('assigned_to') && operatorSearchTerm && !isOperatorValid()" class="mt-1 text-sm text-amber-600">
+            ⚠ {{ t('type_to_search_or_select') }}
+          </p>
+          <p *ngIf="hasValidOperatorSelection()" class="mt-1 text-sm text-green-600">
+            ✓ {{ getSelectedOperatorName() }} - {{ t('selected') }}
+          </p>
+        </div>
 
-          <!-- Items Section -->
-          <div class="rounded-lg border border-border bg-muted/50 p-4">
-            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
-              <div>
-                <h3 class="text-base font-semibold text-foreground">{{ t('items_to_pick') }}</h3>
-                <p class="text-sm text-muted-foreground mt-0.5">{{ t('items_to_pick_description') }}</p>
-              </div>
-              <button z-button zType="outline" zSize="sm" type="button" (click)="addItem()" [zDisabled]="!canAddItem()"
-                class="flex-shrink-0">
-                <svg class="h-4 w-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+        <!-- Priority -->
+        <div class="form-group min-w-0">
+          <label class="block text-sm font-medium text-muted-foreground mb-2">
+            {{ t('priority') }}
+          </label>
+          <z-select formControlName="priority" zSize="lg" class="w-full">
+            <z-select-item zValue="normal">{{ t('normal') }}</z-select-item>
+            <z-select-item zValue="high">{{ t('high') }}</z-select-item>
+            <z-select-item zValue="urgent">{{ t('urgent') }}</z-select-item>
+          </z-select>
+        </div>
+      </div>
+
+      <!-- ── Items Section ───────────────────────────────────── -->
+      <div class="rounded-lg border border-border bg-muted/50 p-4">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+          <div>
+            <h3 class="text-base font-semibold text-foreground">{{ t('items_to_pick') }}</h3>
+            <p class="text-sm text-muted-foreground mt-0.5">{{ t('items_to_pick_description') }}</p>
+          </div>
+          <button z-button zType="outline" zSize="sm" type="button" (click)="addItem()" [zDisabled]="!canAddItem()" class="flex-shrink-0">
+            <svg class="h-4 w-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+            </svg>
+            {{ t('add_item') }}
+          </button>
+        </div>
+
+        <!-- Items FormArray -->
+        <div class="space-y-3" formArrayName="items">
+          <div *ngFor="let item of itemsArray.controls; let i = index"
+            class="relative rounded-lg border border-border bg-background p-4 shadow-sm hover:shadow transition-shadow"
+            [formGroupName]="i">
+
+            <!-- Item header row -->
+            <div class="flex items-center justify-between mb-4">
+              <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-accent text-primary text-sm font-semibold">
+                {{ i + 1 }}
+              </span>
+              <button *ngIf="itemsArray.length > 1" z-button zType="ghost" zSize="icon-sm" type="button"
+                (click)="removeItem(i)" class="text-muted-foreground hover:text-red-600" [attr.aria-label]="t('remove_item')">
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
                 </svg>
-                {{ t('add_item') }}
               </button>
             </div>
 
-            <div class="space-y-3" formArrayName="items">
-              <div *ngFor="let item of itemsArray.controls; let i = index"
-                class="relative rounded-lg border border-border bg-background p-4 shadow-sm hover:shadow transition-shadow"
-                [formGroupName]="i">
-                <div class="flex items-center justify-between mb-4">
-                  <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-accent text-primary text-sm font-semibold">
-                    {{ i + 1 }}
-                  </span>
-                  <button *ngIf="itemsArray.length > 1" z-button zType="ghost" zSize="icon-sm" type="button" (click)="removeItem(i)"
-                    class="text-muted-foreground hover:text-red-600 dark:hover:text-red-400" [attr.aria-label]="t('remove_item')">
-                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-                    </svg>
+            <!-- SKU + Required Qty -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+
+              <!-- SKU Combobox -->
+              <div class="form-group relative min-w-0">
+                <label class="block text-sm font-medium text-muted-foreground mb-1.5">
+                  {{ t('sku') }} <span class="text-red-500">*</span>
+                </label>
+                <div class="relative">
+                  <input type="text"
+                    (focus)="showSkuDropdown[i] = true; ensureComboboxState(i)"
+                    (blur)="onSkuBlur(i)"
+                    [(ngModel)]="skuSearchTerms[i]"
+                    (input)="filterArticlesForItem(i)"
+                    (keydown.enter)="$event.preventDefault(); confirmFirstArticleIfAny(i)"
+                    [ngModelOptions]="{standalone: true}"
+                    placeholder="{{ t('select_sku') }}"
+                    class="block w-full min-w-0 h-10 min-h-10 px-3 py-2 pr-16 border rounded-lg border-border shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground"
+                    [class.border-red-500]="isItemFieldInvalid(i, 'sku') || (skuSearchTerms[i] && !isSkuValid(i))"
+                    [class.border-green-500]="skuSearchTerms[i] && isSkuValid(i) && !isItemFieldInvalid(i, 'sku')" />
+                  <input type="hidden" formControlName="sku" />
+                  <div class="absolute inset-y-0 right-0 flex items-center pr-2 space-x-1">
+                    <button type="button" *ngIf="hasValidSkuSelection(i)" (click)="enableSkuEdit(i)"
+                      class="p-1 text-muted-foreground hover:text-blue-600" [title]="t('edit_selection')">
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                      </svg>
+                    </button>
+                    <button type="button" *ngIf="skuSearchTerms[i] || hasValidSkuSelection(i)" (click)="clearSkuManually(i)"
+                      class="p-1 text-muted-foreground hover:text-red-600" [title]="t('clear_selection')">
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div *ngIf="showSkuDropdown[i]" class="absolute z-10 mt-1 w-full bg-background border border-border rounded-md max-h-56 overflow-auto shadow-lg">
+                  <button type="button" *ngFor="let article of filteredArticlesPerItem[i]"
+                    (mousedown)="$event.preventDefault()" (click)="onSkuSelected(i, article)"
+                    class="w-full text-left px-3 py-2 hover:bg-muted text-sm text-muted-foreground">
+                    {{ article.sku }} - {{ article.name }}
                   </button>
-                </div>
-
-                <!-- Campos principales en una fila -->
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <!-- SKU Combobox -->
-                  <div class="form-group relative min-w-0">
-                    <label class="block text-sm font-medium text-muted-foreground mb-1.5">{{ t('sku') }} <span class="text-red-500">*</span></label>
-                    <div class="relative">
-                      <input type="text" 
-                        (focus)="showSkuDropdown[i] = true; ensureComboboxState(i)" 
-                        (blur)="onSkuBlur(i)"
-                        [(ngModel)]="skuSearchTerms[i]" 
-                        (input)="filterArticlesForItem(i)"
-                        (keydown.enter)="$event.preventDefault(); confirmFirstArticleIfAny(i)" 
-                        [ngModelOptions]="{standalone: true}"
-                        placeholder="{{ t('select_sku') }}"
-                        class="block w-full min-w-0 h-10 min-h-10 px-3 py-2 pr-16 border rounded-lg border-border shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground"
-                        [class.border-red-500]="isItemFieldInvalid(i, 'sku') || (skuSearchTerms[i] && !isSkuValid(i))"
-                        [class.border-green-500]="skuSearchTerms[i] && isSkuValid(i) && !isItemFieldInvalid(i, 'sku')"
-                        [class.focus:ring-red-500]="isItemFieldInvalid(i, 'sku') || (skuSearchTerms[i] && !isSkuValid(i))"
-                        [class.focus:border-red-500]="isItemFieldInvalid(i, 'sku') || (skuSearchTerms[i] && !isSkuValid(i))"
-                        [class.focus:ring-green-500]="skuSearchTerms[i] && isSkuValid(i) && !isItemFieldInvalid(i, 'sku')"
-                        [class.focus:border-green-500]="skuSearchTerms[i] && isSkuValid(i) && !isItemFieldInvalid(i, 'sku')"
-                        [class.border-border]="!isItemFieldInvalid(i, 'sku') && (!skuSearchTerms[i] || isSkuValid(i))"
-                      />
-                      <input type="hidden" formControlName="sku" />
-                      
-                      <!-- Botones de acción -->
-                      <div class="absolute inset-y-0 right-0 flex items-center pr-2 space-x-1">
-                        <!-- Botón de editar (cuando hay selección válida) -->
-                        <button type="button" 
-                          *ngIf="hasValidSkuSelection(i)"
-                          (click)="enableSkuEdit(i)"
-                          class="p-1 text-muted-foreground hover:text-blue-600 focus:outline-none focus:text-blue-600"
-                          [title]="t('edit_selection')">
-                          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
-                          </svg>
-                        </button>
-                        
-                        <!-- Botón de limpiar -->
-                        <button type="button" 
-                          *ngIf="skuSearchTerms[i] || hasValidSkuSelection(i)"
-                          (click)="clearSkuManually(i)"
-                          class="p-1 text-muted-foreground hover:text-red-600 focus:outline-none focus:text-red-600"
-                          [title]="t('clear_selection')">
-                          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-                    <div *ngIf="showSkuDropdown[i]" class="absolute z-10 mt-1 w-full bg-background border border-border rounded-md max-h-56 overflow-auto shadow-lg">
-                      <button type="button" *ngFor="let article of filteredArticlesPerItem[i]" (mousedown)="$event.preventDefault()" (click)="onSkuSelected(i, article)"
-                        class="w-full text-left px-3 py-2 hover:bg-muted text-sm text-muted-foreground">
-                        {{ article.sku }} - {{ article.name }}
-                      </button>
-                      <div *ngIf="(filteredArticlesPerItem[i] || []).length === 0" class="px-3 py-2 text-sm text-muted-foreground">
-                        {{ t('no_results') }}
-                      </div>
-                    </div>
-                    <p *ngIf="isItemFieldInvalid(i, 'sku')" class="mt-1 text-sm text-red-600">
-                      {{ getItemFieldError(i, 'sku') }}
-                    </p>
-                    <p *ngIf="!isItemFieldInvalid(i, 'sku') && skuSearchTerms[i] && !isSkuValid(i)" class="mt-1 text-sm text-amber-600">
-                      ⚠ {{ t('type_to_search_or_select') }}
-                    </p>
-                    <p *ngIf="hasValidSkuSelection(i)" class="mt-1 text-sm text-green-600">
-                      ✓ {{ getSelectedSkuName(i) }} - {{ t('selected') }}
-                    </p>
-                  </div>
-
-                  <!-- Required Quantity -->
-                  <div class="form-group min-w-0">
-                    <label class="block text-sm font-medium text-muted-foreground mb-1.5">{{ t('required_quantity') }}</label>
-                    <input type="number" [(ngModel)]="requiredQuantities[i]" [ngModelOptions]="{standalone: true}" min="1" (input)="onRequiredQuantityChange(i)"
-                      class="w-full h-10 min-h-10 px-3 py-2 border border-border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                      [class.border-red-500]="isItemFieldInvalid(i, 'required_qty')"
-                      [class.focus:ring-red-500]="isItemFieldInvalid(i, 'required_qty')"
-                      [class.focus:border-red-500]="isItemFieldInvalid(i, 'required_qty')" />
-                    <div *ngIf="isItemFieldInvalid(i, 'required_qty')" class="text-red-600 text-sm mt-1">
-                      {{ getItemFieldError(i, 'required_qty') }}
-                    </div>
-                  </div>
-
-                  <!-- Location Combobox -->
-                  <div class="form-group relative min-w-0">
-                    <label class="block text-sm font-medium text-muted-foreground mb-1.5">{{ t('location') }} <span class="text-red-500">*</span></label>
-                    <div class="relative">
-                      <input type="text" 
-                        (focus)="showLocationDropdown[i] = true; ensureComboboxState(i)" 
-                        (blur)="onLocationBlur(i)"
-                        [(ngModel)]="locationSearchTerms[i]" 
-                        (input)="filterLocationsForItem(i)"
-                        (keydown.enter)="$event.preventDefault(); confirmFirstLocationIfAny(i)" 
-                        [ngModelOptions]="{standalone: true}"
-                        placeholder="{{ t('select_location_short') }}"
-                        class="block w-full min-w-0 h-10 min-h-10 px-3 py-2 pr-16 border rounded-lg border-border shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground"
-                        [class.border-red-500]="isItemFieldInvalid(i, 'location') || (locationSearchTerms[i] && !isLocationValid(i))"
-                        [class.border-green-500]="locationSearchTerms[i] && isLocationValid(i) && !isItemFieldInvalid(i, 'location')"
-                        [class.focus:ring-red-500]="isItemFieldInvalid(i, 'location') || (locationSearchTerms[i] && !isLocationValid(i))"
-                        [class.focus:border-red-500]="isItemFieldInvalid(i, 'location') || (locationSearchTerms[i] && !isLocationValid(i))"
-                        [class.focus:ring-green-500]="locationSearchTerms[i] && isLocationValid(i) && !isItemFieldInvalid(i, 'location')"
-                        [class.focus:border-green-500]="locationSearchTerms[i] && isLocationValid(i) && !isItemFieldInvalid(i, 'location')"
-                        [class.border-border]="!isItemFieldInvalid(i, 'location') && (!locationSearchTerms[i] || isLocationValid(i))"
-                      />
-                      <input type="hidden" formControlName="location" />
-                      
-                      <!-- Botones de acción -->
-                      <div class="absolute inset-y-0 right-0 flex items-center pr-2 space-x-1">
-                        <!-- Botón de editar (cuando hay selección válida) -->
-                        <button type="button" 
-                          *ngIf="hasValidLocationSelection(i)"
-                          (click)="enableLocationEdit(i)"
-                          class="p-1 text-muted-foreground hover:text-blue-600 focus:outline-none focus:text-blue-600"
-                          [title]="t('edit_selection')">
-                          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
-                          </svg>
-                        </button>
-                        
-                        <!-- Botón de limpiar -->
-                        <button type="button" 
-                          *ngIf="locationSearchTerms[i] || hasValidLocationSelection(i)"
-                          (click)="clearLocationManually(i)"
-                          class="p-1 text-muted-foreground hover:text-red-600 focus:outline-none focus:text-red-600"
-                          [title]="t('clear_selection')">
-                          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-                    <div *ngIf="showLocationDropdown[i]" class="absolute z-10 mt-1 w-full bg-background border border-border rounded-md max-h-56 overflow-auto shadow-lg">
-                      <button type="button" *ngFor="let loc of filteredLocationsPerItem[i]" (mousedown)="$event.preventDefault()" (click)="onLocationSelected(i, loc)"
-                        class="w-full text-left px-3 py-2 hover:bg-muted text-sm text-muted-foreground">
-                        {{ loc.location_code }} - {{ loc.description }}
-                      </button>
-                      <div *ngIf="(filteredLocationsPerItem[i] || []).length === 0" class="px-3 py-2 text-sm text-muted-foreground">
-                        {{ t('no_results') }}
-                      </div>
-                    </div>
-                    <p *ngIf="isItemFieldInvalid(i, 'location')" class="mt-1 text-sm text-red-600">
-                      {{ getItemFieldError(i, 'location') }}
-                    </p>
-                    <p *ngIf="!isItemFieldInvalid(i, 'location') && locationSearchTerms[i] && !isLocationValid(i)" class="mt-1 text-sm text-amber-600">
-                      ⚠ {{ t('type_to_search_or_select') }}
-                    </p>
-                    <p *ngIf="hasValidLocationSelection(i)" class="mt-1 text-sm text-green-600">
-                      ✓ {{ getSelectedLocationName(i) }} - {{ t('selected') }}
-                    </p>
+                  <div *ngIf="(filteredArticlesPerItem[i] || []).length === 0" class="px-3 py-2 text-sm text-muted-foreground">
+                    {{ t('no_results') }}
                   </div>
                 </div>
+                <p *ngIf="isItemFieldInvalid(i, 'sku')" class="mt-1 text-sm text-red-600">
+                  {{ getItemFieldError(i, 'sku') }}
+                </p>
+                <p *ngIf="!isItemFieldInvalid(i, 'sku') && skuSearchTerms[i] && !isSkuValid(i)" class="mt-1 text-sm text-amber-600">
+                  ⚠ {{ t('type_to_search_or_select') }}
+                </p>
+                <p *ngIf="hasValidSkuSelection(i)" class="mt-1 text-sm text-green-600">
+                  ✓ {{ getSelectedSkuName(i) }} - {{ t('selected') }}
+                </p>
+              </div>
 
-                <!-- Campos de seguimiento (Lotes y Series) -->
-                <div *ngIf="shouldShowLotNumbers(i) || shouldShowSerialNumbers(i)" class="grid grid-cols-1 gap-4 w-full">
-                  
-                  <!-- Lot Numbers Column -->
-                  <div *ngIf="shouldShowLotNumbers(i)" class="form-group w-full relative">
-                    <label class="block text-sm font-medium text-muted-foreground mb-2">
-                      {{ t('lot_numbers') }} 
-                      <span class="ml-1 text-xs" 
-                            [class.text-green-600]="isLotSelectionComplete(i)"
-                            [class.text-orange-600]="!isLotSelectionComplete(i) && getSelectedLotCount(i) > 0"
-                            [class.text-muted-foreground]="getSelectedLotCount(i) === 0">
-                        ({{ getSelectedLotCount(i) }}/{{ getRequiredQuantity(i) }})
-                      </span>
-                    </label>
-                    <div class="flex w-full gap-3" *ngIf="!isLotSelectionComplete(i)">
-                      <div class="relative flex-[8] min-w-0">
-                        <input type="text"
-                          (focus)="showLotDropdown[i] = true; ensureComboboxState(i)"
-                          (blur)="closeLotDropdownLater(i)"
-                          [(ngModel)]="lotSearchTerms[i]"
-                          (input)="filterLotsForItem(i); onManualLotInput(i)"
-                          (keydown.enter)="$event.preventDefault(); handleLotEnter(i)"
-                          [ngModelOptions]="{standalone: true}"
-                          [placeholder]="t('search_select_or_type_lots')"
-                          class="w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-[#3e66ea] text-foreground" />
-                        <input type="hidden" formControlName="lot_numbers" />
-                        <div *ngIf="showLotDropdown[i]" class="absolute z-50 mt-1 w-full bg-background border border-border rounded-md max-h-48 overflow-auto shadow-xl">
-                          <button type="button" *ngFor="let ln of filteredLotsPerItem[i]" (mousedown)="$event.preventDefault()" (click)="onLotSelected(i, ln)"
-                            class="w-full text-left px-3 py-2 hover:bg-muted text-sm text-muted-foreground"
-                            [class.bg-blue-50]="isLotSelected(i, ln)">
-                            {{ ln }}
-                            <span *ngIf="isLotSelected(i, ln)" class="float-right text-blue-600 dark:text-blue-400">✓</span>
-                          </button>
-                          <div *ngIf="(filteredLotsPerItem[i] || []).length === 0" class="px-3 py-2 text-sm text-muted-foreground">
-                            {{ t('no_results') }}
-                          </div>
-                        </div>
-                      </div>
-                      <button type="button" (click)="selectRandomLots(i)"
-                        class="flex-[2] flex-shrink-0 inline-flex items-center justify-center px-3 py-2 border border-border rounded-md text-sm font-medium text-muted-foreground bg-background hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">
-                        <svg class="h-4 w-4 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <rect x="2" y="2" width="20" height="20" rx="3" stroke-width="2" fill="none"/>
-                          <circle cx="8" cy="8" r="1.5" fill="currentColor"/>
-                          <circle cx="16" cy="8" r="1.5" fill="currentColor"/>
-                          <circle cx="12" cy="12" r="1.5" fill="currentColor"/>
-                          <circle cx="8" cy="16" r="1.5" fill="currentColor"/>
-                          <circle cx="16" cy="16" r="1.5" fill="currentColor"/>
-                        </svg>
-                        {{ t('random_selection') }}
-                      </button>
-                    </div>
-                    
-                    <!-- Mensaje cuando está completo -->
-                    <div *ngIf="isLotSelectionComplete(i)" class="text-sm text-green-600 dark:text-green-400 font-medium">
-                      {{ t('lot_selection_complete') }}
-                    </div>
-                    
-                    <!-- Selected lots display -->
-                    <div *ngIf="getSelectedLots(i).length > 0" class="mt-2">
-                      <div class="flex flex-wrap gap-1">
-                        <span *ngFor="let lot of getSelectedLots(i)" 
-                          class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                          {{ lot }}
-                          <button type="button" (click)="removeLot(i, lot)" class="ml-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200">
-                            <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
-                              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
-                            </svg>
-                          </button>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- Serial Numbers Column -->
-                  <div *ngIf="shouldShowSerialNumbers(i)" class="form-group w-full relative">
-                    <label class="block text-sm font-medium text-muted-foreground mb-2">
-                      {{ t('serial_numbers') }}
-                      <span class="ml-1 text-xs" 
-                            [class.text-green-600]="isSerialSelectionComplete(i)"
-                            [class.text-orange-600]="!isSerialSelectionComplete(i) && getSelectedSerialCount(i) > 0"
-                            [class.text-muted-foreground]="getSelectedSerialCount(i) === 0">
-                        ({{ getSelectedSerialCount(i) }}/{{ getRequiredQuantity(i) }})
-                      </span>
-                    </label>
-                    <div class="flex w-full gap-3" *ngIf="!isSerialSelectionComplete(i)">
-                      <div class="relative flex-[8] min-w-0">
-                        <input type="text"
-                          (focus)="showSerialDropdown[i] = true; ensureComboboxState(i)"
-                          (blur)="closeSerialDropdownLater(i)"
-                          [(ngModel)]="serialSearchTerms[i]"
-                          (input)="filterSerialsForItem(i); onManualSerialInput(i)"
-                          (keydown.enter)="$event.preventDefault(); handleSerialEnter(i)"
-                          [ngModelOptions]="{standalone: true}"
-                          [placeholder]="t('search_select_or_type_serials')"
-                          class="w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-[#3e66ea] text-foreground" />
-                        <input type="hidden" formControlName="serial_numbers" />
-                        <div *ngIf="showSerialDropdown[i]" class="absolute z-50 mt-1 w-full bg-background border border-border rounded-md max-h-48 overflow-auto shadow-xl">
-                          <button type="button" *ngFor="let sn of filteredSerialsPerItem[i]" (mousedown)="$event.preventDefault()" (click)="onSerialSelected(i, sn)"
-                            class="w-full text-left px-3 py-2 hover:bg-muted text-sm text-muted-foreground"
-                            [class.bg-blue-50]="isSerialSelected(i, sn)">
-                            {{ sn }}
-                            <span *ngIf="isSerialSelected(i, sn)" class="float-right text-blue-600 dark:text-blue-400">✓</span>
-                          </button>
-                          <div *ngIf="(filteredSerialsPerItem[i] || []).length === 0" class="px-3 py-2 text-sm text-muted-foreground">
-                            {{ t('no_results') }}
-                          </div>
-                        </div>
-                      </div>
-                      <button type="button" (click)="selectRandomSerials(i)"
-                        class="flex-[2] flex-shrink-0 inline-flex items-center justify-center px-3 py-2 border border-border rounded-md text-sm font-medium text-muted-foreground bg-background hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">
-                        <svg class="h-4 w-4 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <rect x="2" y="2" width="20" height="20" rx="3" stroke-width="2" fill="none"/>
-                          <circle cx="8" cy="8" r="1.5" fill="currentColor"/>
-                          <circle cx="16" cy="8" r="1.5" fill="currentColor"/>
-                          <circle cx="12" cy="12" r="1.5" fill="currentColor"/>
-                          <circle cx="8" cy="16" r="1.5" fill="currentColor"/>
-                          <circle cx="16" cy="16" r="1.5" fill="currentColor"/>
-                        </svg>
-                        {{ t('random_selection') }}
-                      </button>
-                    </div>
-                    
-                    <!-- Mensaje cuando está completo -->
-                    <div *ngIf="isSerialSelectionComplete(i)" class="text-sm text-green-600 dark:text-green-400 font-medium">
-                      {{ t('serial_selection_complete') }}
-                    </div>
-                    
-                    <!-- Selected serials display -->
-                    <div *ngIf="getSelectedSerials(i).length > 0" class="mt-2">
-                      <div class="flex flex-wrap gap-1">
-                        <span *ngFor="let serial of getSelectedSerials(i)" 
-                          class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                          {{ serial }}
-                          <button type="button" (click)="removeSerial(i, serial)" class="ml-1 text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-200">
-                            <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
-                              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
-                            </svg>
-                          </button>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
+              <!-- Required Qty (formControlName — triggers FEFO prefill on blur) -->
+              <div class="form-group min-w-0">
+                <label class="block text-sm font-medium text-muted-foreground mb-1.5">
+                  {{ t('required_quantity') }} <span class="text-red-500">*</span>
+                </label>
+                <input type="number" formControlName="required_qty" min="0.001" step="0.001"
+                  (blur)="onSkuOrQtyChange(i)"
+                  class="w-full h-10 min-h-10 px-3 py-2 border border-border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary text-foreground [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  [class.border-red-500]="isItemFieldInvalid(i, 'required_qty')" />
+                <div *ngIf="isItemFieldInvalid(i, 'required_qty')" class="text-red-600 text-sm mt-1">
+                  {{ getItemFieldError(i, 'required_qty') }}
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- Notes Section -->
-          <div class="form-group">
-            <label class="block text-sm font-medium text-muted-foreground mb-2">{{ t('notes_optional') }}</label>
-            <textarea formControlName="notes" rows="3" [placeholder]="t('add_special_instructions')"
-              class="w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-[#3e66ea] text-foreground"></textarea>
+            <!-- ── Allocations (cross-location FEFO) ────────── -->
+            <div class="mt-1" formArrayName="allocations">
+              <div class="flex items-center justify-between mb-2">
+                <div class="flex items-center gap-2">
+                  <span class="text-sm font-medium text-foreground">Ubicaciones (FEFO)</span>
+                  <span *ngIf="validateAllocationSum(i)" class="text-red-500 text-xs font-medium">
+                    · {{ validateAllocationSum(i) }}
+                  </span>
+                </div>
+                <button type="button" (click)="addAllocation(i)"
+                  class="text-xs text-primary hover:text-primary/80 font-medium underline-offset-2 hover:underline">
+                  + Agregar ubicación
+                </button>
+              </div>
+
+              <!-- Stock warning banner -->
+              <div *ngIf="stockWarnings[i]"
+                class="text-xs text-amber-700 mb-2 p-2 rounded-md bg-amber-50 border border-amber-200 dark:bg-amber-950 dark:text-amber-300 dark:border-amber-800">
+                {{ stockWarnings[i] }}
+              </div>
+
+              <!-- Allocation rows -->
+              <div *ngFor="let alloc of getAllocationsArray(i).controls; let j = index"
+                [formGroupName]="j"
+                class="rounded-lg border border-border bg-muted/30 p-3 mb-2">
+                <div class="grid grid-cols-12 gap-2 items-end">
+
+                  <!-- Location -->
+                  <div class="col-span-4">
+                    <label class="block text-xs text-muted-foreground mb-1">Ubicación *</label>
+                    <input formControlName="location" placeholder="ej: A-01-01"
+                      (blur)="onAllocLocationChange(i, j)"
+                      class="w-full h-8 px-2 py-1 border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary text-foreground"
+                      [class.border-red-500]="asGroup(alloc).get('location')?.invalid && asGroup(alloc).get('location')?.touched" />
+                  </div>
+
+                  <!-- Quantity -->
+                  <div class="col-span-3">
+                    <label class="block text-xs text-muted-foreground mb-1">Cantidad *</label>
+                    <input type="number" formControlName="quantity" placeholder="0" min="0.001" step="0.001"
+                      class="w-full h-8 px-2 py-1 border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary text-foreground [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                      [class.border-red-500]="asGroup(alloc).get('quantity')?.invalid && asGroup(alloc).get('quantity')?.touched" />
+                  </div>
+
+                  <!-- Lot Number -->
+                  <div class="col-span-4">
+                    <label class="block text-xs text-muted-foreground mb-1">Lote</label>
+                    <input formControlName="lot_number" placeholder="ej: LOT-001"
+                      class="w-full h-8 px-2 py-1 border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary text-foreground" />
+                  </div>
+
+                  <!-- Remove button -->
+                  <div class="col-span-1 flex items-end justify-center pb-0.5">
+                    <button type="button" (click)="removeAllocation(i, j)"
+                      class="text-red-400 hover:text-red-600 transition-colors" [title]="'Eliminar'">
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Expiration date display -->
+                <div *ngIf="asGroup(alloc).get('expiration_date_display')?.value" class="mt-1 text-xs text-muted-foreground">
+                  Vence: {{ asGroup(alloc).get('expiration_date_display')?.value }}
+                </div>
+
+                <!-- F3: Available qty indicator -->
+                <div class="mt-1 text-xs"
+                  [class.text-red-500]="isAllocInsufficient(i, j)"
+                  [class.text-green-600]="!isAllocInsufficient(i, j) && getAvailableQty(i, j) !== null"
+                  [class.text-muted-foreground]="getAvailableQty(i, j) === null">
+                  <span *ngIf="getAvailableQty(i, j) !== null">
+                    Disponible en {{ asGroup(alloc).get('location')?.value }}: {{ getAvailableQty(i, j) | number:'1.0-3' }} uds
+                    <span *ngIf="isAllocInsufficient(i, j)" class="font-medium"> — Stock insuficiente</span>
+                  </span>
+                  <span *ngIf="getAvailableQty(i, j) === null && asGroup(alloc).get('location')?.value" class="italic">
+                    Cargando disponibilidad...
+                  </span>
+                </div>
+              </div>
+
+              <!-- Empty allocations state -->
+              <div *ngIf="getAllocationsArray(i).length === 0"
+                class="text-sm text-muted-foreground text-center py-4 border border-dashed border-border rounded-lg">
+                Ingresa SKU y cantidad requerida para auto-asignar ubicaciones FEFO,<br>o agrega manualmente.
+              </div>
+            </div>
+            <!-- /allocations -->
+
           </div>
-        </form>
+        </div>
+        <!-- /items FormArray -->
+      </div>
+      <!-- /items section -->
+
+      <!-- ── Notes ───────────────────────────────────────────── -->
+      <div class="form-group">
+        <label class="block text-sm font-medium text-muted-foreground mb-2">{{ t('notes_optional') }}</label>
+        <textarea formControlName="notes" rows="3" [placeholder]="t('add_special_instructions')"
+          class="w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-[#3e66ea] text-foreground"></textarea>
+      </div>
+
+    </form>
   </div>
 
+  <!-- ── Footer ─────────────────────────────────────────────── -->
   <div drawerFooter class="flex flex-row gap-2 pb-6">
     <button z-button zType="outline" zSize="lg" type="button" (click)="close()" class="flex-1">
       {{ t('cancel') }}
     </button>
+
+    <!-- Iniciar picking — visible when editing a task that is open or assigned -->
+    <button *ngIf="isEditing && (task?.status === 'open' || task?.status === 'assigned')"
+      z-button zType="outline" zSize="lg" type="button"
+      (click)="startPicking()" [zLoading]="isLoading"
+      class="flex-1 border-primary text-primary hover:bg-primary/10">
+      Iniciar picking
+    </button>
+
     <button z-button zType="default" zSize="lg" type="button" (click)="onSubmit()"
-      [zDisabled]="isLoading || !isFormComplete()" [zLoading]="isLoading"
+      [zDisabled]="isLoading || !canSubmit()" [zLoading]="isLoading"
       class="flex-1">
       {{ isLoading ? (task ? t('updating') : t('creating')) : (task ? t('update') : t('create')) }}
     </button>

--- a/src/app/components/picking-tasks/picking-task-form/picking-task-form.component.spec.ts
+++ b/src/app/components/picking-tasks/picking-task-form/picking-task-form.component.spec.ts
@@ -1,0 +1,308 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormArray, FormGroup, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { ChangeDetectorRef } from '@angular/core';
+
+import { PickingTaskFormComponent } from './picking-task-form.component';
+import { PickingTaskService } from '@app/services/picking-task.service';
+import { InventoryService } from '@app/services/inventory.service';
+import { LocationService } from '@app/services/location.service';
+import { UserService } from '@app/services/user.service';
+import { ArticleService } from '@app/services/article.service';
+import { AlertService } from '@app/services/extras/alert.service';
+import { LoadingService } from '@app/services/extras/loading.service';
+import { LanguageService } from '@app/services/extras/language.service';
+import { DrawerComponent } from '@app/shared/components/drawer';
+import { ZardButtonComponent } from '@app/shared/components/button/button.component';
+import { ZardSelectComponent } from '@app/shared/components/select/select.component';
+import { ZardSelectItemComponent } from '@app/shared/components/select/select-item.component';
+
+// ── Minimal stubs ────────────────────────────────────────────
+
+const successResp = (data: any) => ({ result: { success: true, message: '' }, data });
+const failResp = (msg: string) => ({ result: { success: false, message: msg }, data: null });
+
+function mockLanguageService() {
+  return { t: (key: string) => key };
+}
+
+function mockAlertService() {
+  return { success: jasmine.createSpy(), error: jasmine.createSpy(), warning: jasmine.createSpy() };
+}
+
+function mockLoadingService() {
+  return { show: jasmine.createSpy(), hide: jasmine.createSpy() };
+}
+
+function mockLocationService() {
+  return { getAll: () => Promise.resolve(successResp([])) };
+}
+
+function mockUserService() {
+  return { getAll: () => Promise.resolve(successResp([])) };
+}
+
+function mockArticleService() {
+  return { getAll: () => Promise.resolve(successResp([])) };
+}
+
+const defaultPickSuggestionsResp = successResp({
+  allocations: [
+    { location: 'LOC-A', quantity: 60, lot_number: 'L001', expiration_date: '2027-01-01' },
+    { location: 'LOC-B', quantity: 40, lot_number: 'L002', expiration_date: '2027-06-01' },
+  ],
+  total_found: 100,
+  requested: 100,
+  sufficient: true,
+});
+
+const insufficientPickSuggestionsResp = successResp({
+  allocations: [
+    { location: 'LOC-A', quantity: 30, lot_number: 'L001' },
+  ],
+  total_found: 30,
+  requested: 100,
+  sufficient: false,
+});
+
+// ── Test suite ───────────────────────────────────────────────
+
+describe('PickingTaskFormComponent', () => {
+  let component: PickingTaskFormComponent;
+  let fixture: ComponentFixture<PickingTaskFormComponent>;
+  let inventoryServiceSpy: jasmine.SpyObj<InventoryService>;
+  let pickingTaskServiceSpy: jasmine.SpyObj<PickingTaskService>;
+  let alertServiceSpy: ReturnType<typeof mockAlertService>;
+
+  beforeEach(async () => {
+    inventoryServiceSpy = jasmine.createSpyObj('InventoryService', [
+      'getPickSuggestions',
+      'getBySkuAndLocation',
+    ]);
+    inventoryServiceSpy.getPickSuggestions.and.returnValue(Promise.resolve(defaultPickSuggestionsResp as any));
+    inventoryServiceSpy.getBySkuAndLocation.and.returnValue(Promise.resolve(null));
+
+    pickingTaskServiceSpy = jasmine.createSpyObj('PickingTaskService', [
+      'create', 'update', 'start',
+    ]);
+    pickingTaskServiceSpy.create.and.returnValue(Promise.resolve(successResp({}) as any));
+    pickingTaskServiceSpy.update.and.returnValue(Promise.resolve(successResp({}) as any));
+    pickingTaskServiceSpy.start.and.returnValue(Promise.resolve(successResp({}) as any));
+
+    alertServiceSpy = mockAlertService();
+
+    await TestBed.configureTestingModule({
+      imports: [
+        PickingTaskFormComponent,
+        CommonModule,
+        ReactiveFormsModule,
+        FormsModule,
+      ],
+      providers: [
+        { provide: PickingTaskService, useValue: pickingTaskServiceSpy },
+        { provide: InventoryService, useValue: inventoryServiceSpy },
+        { provide: LocationService, useValue: mockLocationService() },
+        { provide: UserService, useValue: mockUserService() },
+        { provide: ArticleService, useValue: mockArticleService() },
+        { provide: AlertService, useValue: alertServiceSpy },
+        { provide: LoadingService, useValue: mockLoadingService() },
+        { provide: LanguageService, useValue: mockLanguageService() },
+        ChangeDetectorRef,
+      ],
+    })
+    .overrideComponent(PickingTaskFormComponent, {
+      // Stub heavy UI components to simplify rendering
+      remove: { imports: [DrawerComponent, ZardButtonComponent, ZardSelectComponent, ZardSelectItemComponent] },
+      add: { imports: [] },
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PickingTaskFormComponent);
+    component = fixture.componentInstance;
+    // Skip ngOnInit's async loadData to keep tests fast
+    spyOn(component, 'loadData').and.returnValue(Promise.resolve());
+    fixture.detectChanges();
+    // Manually trigger ngOnInit logic after stubbing loadData
+    await component.ngOnInit();
+  });
+
+  // ── Helpers ──────────────────────────────────────────────
+
+  function getItemGroup(i = 0): FormGroup {
+    return component.getItemsArray().at(i) as FormGroup;
+  }
+
+  function getAllocsArray(i = 0): FormArray {
+    return component.getAllocationsArray(i);
+  }
+
+  // ── TestAllocationFormArray_AddRemove ──────────────────
+
+  it('TestAllocationFormArray_AddRemove — add and remove allocations correctly', () => {
+    // Ensure at least one item exists
+    expect(component.getItemsArray().length).toBeGreaterThanOrEqual(1);
+
+    // Add two allocations
+    component.addAllocation(0);
+    component.addAllocation(0);
+    expect(getAllocsArray(0).length).toBe(2);
+
+    // Remove the first one
+    component.removeAllocation(0, 0);
+    expect(getAllocsArray(0).length).toBe(1);
+  });
+
+  // ── TestAllocationSumValidation_Match ─────────────────
+
+  it('TestAllocationSumValidation_Match — canSubmit is true when sum matches required_qty', () => {
+    // Set sku and required_qty on the item
+    const itemGroup = getItemGroup(0);
+    itemGroup.get('sku')!.setValue('SKU-001');
+    itemGroup.get('required_qty')!.setValue(100);
+
+    // Add two allocations that sum to 100
+    component.addAllocation(0);
+    component.addAllocation(0);
+    const allocs = getAllocsArray(0);
+    (allocs.at(0) as FormGroup).get('location')!.setValue('LOC-A');
+    (allocs.at(0) as FormGroup).get('quantity')!.setValue(60);
+    (allocs.at(1) as FormGroup).get('location')!.setValue('LOC-B');
+    (allocs.at(1) as FormGroup).get('quantity')!.setValue(40);
+
+    expect(component.validateAllocationSum(0)).toBeNull();
+    expect(component.canSubmit()).toBeTrue();
+  });
+
+  // ── TestAllocationSumValidation_Mismatch ──────────────
+
+  it('TestAllocationSumValidation_Mismatch — canSubmit is false when sum differs from required_qty', () => {
+    const itemGroup = getItemGroup(0);
+    itemGroup.get('sku')!.setValue('SKU-001');
+    itemGroup.get('required_qty')!.setValue(100);
+
+    component.addAllocation(0);
+    const allocs = getAllocsArray(0);
+    (allocs.at(0) as FormGroup).get('location')!.setValue('LOC-A');
+    (allocs.at(0) as FormGroup).get('quantity')!.setValue(50); // only 50, not 100
+
+    expect(component.validateAllocationSum(0)).not.toBeNull();
+    expect(component.canSubmit()).toBeFalse();
+  });
+
+  // ── TestPrefillAllocations_FromFEFO ───────────────────
+
+  it('TestPrefillAllocations_FromFEFO — pre-fills allocations from pick-suggestions (2 locations)', fakeAsync(async () => {
+    const itemGroup = getItemGroup(0);
+    itemGroup.get('sku')!.setValue('SKU-001');
+    itemGroup.get('required_qty')!.setValue(100);
+
+    inventoryServiceSpy.getPickSuggestions.and.returnValue(Promise.resolve(defaultPickSuggestionsResp as any));
+    await component.prefillAllocationsForItem(0, 'SKU-001', 100);
+    tick();
+
+    const allocs = getAllocsArray(0);
+    expect(allocs.length).toBe(2);
+    expect((allocs.at(0) as FormGroup).get('location')!.value).toBe('LOC-A');
+    expect((allocs.at(0) as FormGroup).get('quantity')!.value).toBe(60);
+    expect((allocs.at(1) as FormGroup).get('location')!.value).toBe('LOC-B');
+    expect((allocs.at(1) as FormGroup).get('quantity')!.value).toBe(40);
+    expect(component.stockWarnings[0]).toBeUndefined();
+  }));
+
+  // ── TestPrefillAllocations_Insufficient ───────────────
+
+  it('TestPrefillAllocations_Insufficient — shows warning when stock is insufficient', fakeAsync(async () => {
+    inventoryServiceSpy.getPickSuggestions.and.returnValue(Promise.resolve(insufficientPickSuggestionsResp as any));
+    await component.prefillAllocationsForItem(0, 'SKU-001', 100);
+    tick();
+
+    expect(component.stockWarnings[0]).toBeDefined();
+    expect(component.stockWarnings[0]).toContain('30 uds');
+  }));
+
+  // ── TestAvailableQty_Sufficient_Green ─────────────────
+
+  it('TestAvailableQty_Sufficient_Green — isAllocInsufficient is false when qty <= available', fakeAsync(async () => {
+    // Set up allocation with quantity 50
+    component.addAllocation(0);
+    const allocs = getAllocsArray(0);
+    (allocs.at(0) as FormGroup).get('location')!.setValue('LOC-A');
+    (allocs.at(0) as FormGroup).get('quantity')!.setValue(50);
+
+    // Mock inventory returns available_qty = 100
+    inventoryServiceSpy.getBySkuAndLocation.and.returnValue(
+      Promise.resolve(successResp({ quantity: 120, reserved_qty: 20, available_qty: 100 }) as any)
+    );
+    await component.loadAvailableQtyForAlloc(0, 0, 'SKU-001', 'LOC-A');
+    tick();
+
+    expect(component.getAvailableQty(0, 0)).toBe(100);
+    expect(component.isAllocInsufficient(0, 0)).toBeFalse();
+  }));
+
+  // ── TestAvailableQty_Insufficient_Red ─────────────────
+
+  it('TestAvailableQty_Insufficient_Red — isAllocInsufficient is true when qty > available', fakeAsync(async () => {
+    component.addAllocation(0);
+    const allocs = getAllocsArray(0);
+    (allocs.at(0) as FormGroup).get('location')!.setValue('LOC-A');
+    (allocs.at(0) as FormGroup).get('quantity')!.setValue(80);
+
+    inventoryServiceSpy.getBySkuAndLocation.and.returnValue(
+      Promise.resolve(successResp({ quantity: 50, reserved_qty: 0, available_qty: 50 }) as any)
+    );
+    await component.loadAvailableQtyForAlloc(0, 0, 'SKU-001', 'LOC-A');
+    tick();
+
+    expect(component.getAvailableQty(0, 0)).toBe(50);
+    expect(component.isAllocInsufficient(0, 0)).toBeTrue();
+  }));
+
+  // ── TestStartPicking_CallsService ─────────────────────
+
+  it('TestStartPicking_CallsService — calls pickingTaskService.start with the task id', fakeAsync(async () => {
+    component.task = {
+      id: 'task-123',
+      task_id: 'PT-001',
+      created_by: 'u1',
+      assigned_to: 'u2',
+      status: 'open',
+      priority: 'normal',
+      items: [],
+      created_at: '',
+      updated_at: '',
+    };
+
+    await component.startPicking();
+    tick();
+
+    expect(pickingTaskServiceSpy.start).toHaveBeenCalledWith('task-123');
+  }));
+
+  // ── TestStartPicking_ErrorShowsAlert ──────────────────
+
+  it('TestStartPicking_ErrorShowsAlert — shows alert when start fails with backend error', fakeAsync(async () => {
+    component.task = {
+      id: 'task-456',
+      task_id: 'PT-002',
+      created_by: 'u1',
+      assigned_to: 'u2',
+      status: 'open',
+      priority: 'normal',
+      items: [],
+      created_at: '',
+      updated_at: '',
+    };
+
+    pickingTaskServiceSpy.start.and.returnValue(
+      Promise.resolve(failResp('Stock insuficiente para SKU-001 en LOC-A') as any)
+    );
+
+    await component.startPicking();
+    tick();
+
+    expect(alertServiceSpy.error).toHaveBeenCalled();
+    const errorMsg = (alertServiceSpy.error as jasmine.Spy).calls.mostRecent().args[0] as string;
+    expect(errorMsg.toLowerCase()).toContain('insuficiente');
+  }));
+});

--- a/src/app/components/picking-tasks/picking-task-form/picking-task-form.component.ts
+++ b/src/app/components/picking-tasks/picking-task-form/picking-task-form.component.ts
@@ -1,14 +1,16 @@
 import { Component, Input, Output, EventEmitter, OnInit, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, FormArray, Validators, ReactiveFormsModule } from '@angular/forms';
+import {
+	FormBuilder, FormGroup, FormArray,
+	Validators, ReactiveFormsModule, AbstractControl
+} from '@angular/forms';
 import { FormsModule } from '@angular/forms';
 import { PickingTask, CreatePickingTaskRequest } from '@app/models/picking-task.model';
+import { LocationAllocation } from '@app/models/lot-entry.model';
 import { Location } from '@app/models/location.model';
 import { User } from '@app/models/user.model';
 import { Article } from '@app/models/article.model';
 import { PickingTaskService } from '@app/services/picking-task.service';
-import { LotService } from '@app/services/lot.service';
-import { SerialService } from '@app/services/serial.service';
 import { LocationService } from '@app/services/location.service';
 import { InventoryService } from '@app/services/inventory.service';
 import { UserService } from '@app/services/user.service';
@@ -17,7 +19,6 @@ import { AlertService } from '@app/services/extras/alert.service';
 import { LoadingService } from '@app/services/extras/loading.service';
 import { LanguageService } from '@app/services/extras/language.service';
 import { getDisplayableApiError, humanizeApiError } from '@app/utils';
-import { PickSuggestion } from '@app/models/pick-suggestion.model';
 import { DrawerComponent } from '@app/shared/components/drawer';
 import { ZardSelectComponent } from '../../../shared/components/select/select.component';
 import { ZardSelectItemComponent } from '../../../shared/components/select/select-item.component';
@@ -26,7 +27,10 @@ import { ZardButtonComponent } from '../../../shared/components/button/button.co
 @Component({
 	selector: 'app-picking-task-form',
 	standalone: true,
-	imports: [CommonModule, ReactiveFormsModule, FormsModule, DrawerComponent, ZardButtonComponent, ZardSelectComponent, ZardSelectItemComponent],
+	imports: [
+		CommonModule, ReactiveFormsModule, FormsModule,
+		DrawerComponent, ZardButtonComponent, ZardSelectComponent, ZardSelectItemComponent
+	],
 	templateUrl: './picking-task-form.component.html',
 	styleUrls: ['./picking-task-form.component.css']
 })
@@ -43,29 +47,21 @@ export class PickingTaskFormComponent implements OnInit {
 	isLoading = false;
 	isEditing = false;
 
+	// SKU combobox state per item index
 	skuSearchTerms: string[] = [];
-	locationSearchTerms: string[] = [];
 	showSkuDropdown: boolean[] = [];
-	showLocationDropdown: boolean[] = [];
 	filteredArticlesPerItem: Article[][] = [];
-	filteredLocationsPerItem: Location[][] = [];
 
-	availableLotsPerItem: string[][] = [];
-	availableSerialsPerItem: string[][] = [];
-	filteredLotsPerItem: string[][] = [];
-	filteredSerialsPerItem: string[][] = [];
-	/** Pick suggestions per item index (rotation + lowest qty first); used to sort location and lot options. */
-	pickSuggestionsPerItem: PickSuggestion[][] = [];
-	lotSearchTerms: string[] = [];
-	serialSearchTerms: string[] = [];
-	showLotDropdown: boolean[] = [];
-	showSerialDropdown: boolean[] = [];
-	requiredQuantities: number[] = [];
-	
-	// Operator combobox properties
-	operatorSearchTerm: string = '';
-	showOperatorDropdown: boolean = false;
+	// Operator combobox state
+	operatorSearchTerm = '';
+	showOperatorDropdown = false;
 	filteredOperators: User[] = [];
+
+	// F2: stock warning per item index
+	stockWarnings: Record<number, string> = {};
+
+	// F3: available qty cache, key = "itemIndex-allocIndex"
+	availableQtyPerAlloc: Record<string, number> = {};
 
 	constructor(
 		private fb: FormBuilder,
@@ -73,8 +69,6 @@ export class PickingTaskFormComponent implements OnInit {
 		private locationService: LocationService,
 		private userService: UserService,
 		private articleService: ArticleService,
-		private lotService: LotService,
-		private serialService: SerialService,
 		private inventoryService: InventoryService,
 		private alertService: AlertService,
 		private loadingService: LoadingService,
@@ -112,8 +106,258 @@ export class PickingTaskFormComponent implements OnInit {
 		this.cancel.emit();
 	}
 
+	// ─────────────────────────────────────────────────────────────
+	//  Angular FormGroup Helpers (required for nested FormArray)
+	// ─────────────────────────────────────────────────────────────
 
-	// Operator dropdown validation and advanced methods
+	/** Cast AbstractControl → FormGroup for template access. */
+	asGroup(control: AbstractControl): FormGroup {
+		return control as FormGroup;
+	}
+
+	getItemsArray(): FormArray {
+		return this.form.get('items') as FormArray;
+	}
+
+	getAllocationsArray(itemIndex: number): FormArray {
+		return (this.getItemsArray().at(itemIndex) as FormGroup).get('allocations') as FormArray;
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Form Group Factories
+	// ─────────────────────────────────────────────────────────────
+
+	private createItemGroup(item?: { sku?: string; required_qty?: number; allocations?: LocationAllocation[] }): FormGroup {
+		const allocs = item?.allocations || [];
+		return this.fb.group({
+			sku: [item?.sku || '', Validators.required],
+			required_qty: [item?.required_qty || 0, [Validators.required, Validators.min(0.001)]],
+			allocations: this.fb.array(allocs.map(a => this.createAllocationGroup(a))),
+		});
+	}
+
+	private createAllocationGroup(alloc?: Partial<LocationAllocation>): FormGroup {
+		return this.fb.group({
+			location: [alloc?.location || '', Validators.required],
+			quantity: [alloc?.quantity || 0, [Validators.required, Validators.min(0.001)]],
+			lot_number: [alloc?.lot_number || ''],
+			expiration_date_display: [alloc?.expiration_date || ''],
+		});
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Allocation Management — F2
+	// ─────────────────────────────────────────────────────────────
+
+	addAllocation(itemIndex: number): void {
+		this.getAllocationsArray(itemIndex).push(this.createAllocationGroup());
+	}
+
+	removeAllocation(itemIndex: number, allocIndex: number): void {
+		this.getAllocationsArray(itemIndex).removeAt(allocIndex);
+		this.reindexAvailableQtyCache(itemIndex, allocIndex);
+	}
+
+	private reindexAvailableQtyCache(itemIndex: number, removedAllocIndex: number): void {
+		const updated: Record<string, number> = {};
+		for (const [key, val] of Object.entries(this.availableQtyPerAlloc)) {
+			const [ki, ji] = key.split('-').map(Number);
+			if (ki !== itemIndex) {
+				updated[key] = val;
+			} else if (ji < removedAllocIndex) {
+				updated[key] = val;
+			} else if (ji > removedAllocIndex) {
+				updated[`${ki}-${ji - 1}`] = val;
+			}
+			// ji === removedAllocIndex → dropped
+		}
+		this.availableQtyPerAlloc = updated;
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  FEFO Pre-fill — F2b
+	// ─────────────────────────────────────────────────────────────
+
+	/** Triggered when SKU or required_qty changes — prefills allocations from backend. */
+	async onSkuOrQtyChange(itemIndex: number): Promise<void> {
+		const item = this.getItemsArray().at(itemIndex) as FormGroup;
+		const sku: string = item.get('sku')?.value || '';
+		const qty = Number(item.get('required_qty')?.value);
+		if (sku && qty > 0) {
+			await this.prefillAllocationsForItem(itemIndex, sku, qty);
+		}
+	}
+
+	async prefillAllocationsForItem(itemIndex: number, sku: string, requiredQty: number): Promise<void> {
+		if (!sku || requiredQty <= 0) return;
+		try {
+			const resp = await this.inventoryService.getPickSuggestions(sku, requiredQty);
+			if (!resp.result.success) return;
+
+			const raw = resp.data as any;
+			let allocations: LocationAllocation[] = [];
+			let sufficient = true;
+
+			if (raw && typeof raw === 'object' && 'allocations' in raw) {
+				// New PickSuggestionResponse (H3)
+				allocations = (raw.allocations || []) as LocationAllocation[];
+				sufficient = raw.sufficient ?? true;
+			} else if (Array.isArray(raw)) {
+				// Legacy PickSuggestion[] fallback
+				allocations = (raw as any[]).map((s: any) => ({
+					location: s.location as string,
+					quantity: s.quantity as number,
+					lot_number: s.lot_number || undefined,
+					expiration_date: s.expiration_date || undefined,
+				}));
+				const totalFound = allocations.reduce((sum, a) => sum + a.quantity, 0);
+				sufficient = totalFound >= requiredQty;
+			}
+
+			// Replace allocations in form
+			const allocsArray = this.getAllocationsArray(itemIndex);
+			allocsArray.clear();
+			// Clear the cache for this item
+			this.availableQtyPerAlloc = Object.fromEntries(
+				Object.entries(this.availableQtyPerAlloc).filter(([k]) => !k.startsWith(`${itemIndex}-`))
+			);
+
+			for (const s of allocations) {
+				allocsArray.push(this.createAllocationGroup(s));
+			}
+
+			// Stock warning if insufficient
+			if (!sufficient) {
+				const totalFound = allocations.reduce((sum, a) => sum + a.quantity, 0);
+				this.stockWarnings[itemIndex] =
+					`⚠️ Solo se pueden asignar ${totalFound} uds — se requieren ${requiredQty}. ` +
+					`Stock insuficiente en todas las ubicaciones.`;
+			} else {
+				delete this.stockWarnings[itemIndex];
+			}
+
+			// Load F3 available qty for each allocation
+			for (let j = 0; j < allocsArray.length; j++) {
+				const ag = allocsArray.at(j) as FormGroup;
+				const loc: string = ag.get('location')?.value || '';
+				if (sku && loc) {
+					this.loadAvailableQtyForAlloc(itemIndex, j, sku, loc);
+				}
+			}
+
+			this.cdr.detectChanges();
+		} catch (err) {
+			console.error('prefillAllocationsForItem error', err);
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Allocation Sum Validation — F2c
+	// ─────────────────────────────────────────────────────────────
+
+	validateAllocationSum(itemIndex: number): string | null {
+		const item = this.getItemsArray().at(itemIndex) as FormGroup;
+		const requiredQty = Number(item.get('required_qty')?.value) || 0;
+		if (requiredQty <= 0) return null;
+		const allocs = this.getAllocationsArray(itemIndex).controls;
+		if (allocs.length === 0) return null; // allow empty while user is entering data
+		const sumQty = allocs.reduce((s, a) => s + (Number(a.get('quantity')?.value) || 0), 0);
+		if (Math.abs(sumQty - requiredQty) > 0.001) {
+			return `Suma allocations (${sumQty.toFixed(3)}) ≠ requerido (${requiredQty})`;
+		}
+		return null;
+	}
+
+	canSubmit(): boolean {
+		if (this.form.invalid) return false;
+		const items = this.getItemsArray().controls;
+		for (let i = 0; i < items.length; i++) {
+			if (this.getAllocationsArray(i).length === 0) return false;
+			if (this.validateAllocationSum(i) !== null) return false;
+		}
+		return true;
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Available Qty per Allocation — F3
+	// ─────────────────────────────────────────────────────────────
+
+	async loadAvailableQtyForAlloc(itemIndex: number, allocIndex: number, sku: string, location: string): Promise<void> {
+		if (!sku || !location) return;
+		const key = `${itemIndex}-${allocIndex}`;
+		try {
+			const inv = await this.inventoryService.getBySkuAndLocation(sku, location);
+			if (inv && inv.result.success && inv.data) {
+				this.availableQtyPerAlloc[key] =
+					inv.data.available_qty ?? (inv.data.quantity - (inv.data.reserved_qty || 0));
+			} else {
+				this.availableQtyPerAlloc[key] = 0;
+			}
+		} catch {
+			this.availableQtyPerAlloc[key] = 0;
+		}
+		this.cdr.detectChanges();
+	}
+
+	getAvailableQty(itemIndex: number, allocIndex: number): number | null {
+		const key = `${itemIndex}-${allocIndex}`;
+		return this.availableQtyPerAlloc[key] ?? null;
+	}
+
+	isAllocInsufficient(itemIndex: number, allocIndex: number): boolean {
+		const avail = this.getAvailableQty(itemIndex, allocIndex);
+		if (avail === null) return false;
+		const alloc = this.getAllocationsArray(itemIndex).at(allocIndex) as FormGroup;
+		return (Number(alloc.get('quantity')?.value) || 0) > avail;
+	}
+
+	/** Called on blur of allocation location input to refresh available qty. */
+	onAllocLocationChange(itemIndex: number, allocIndex: number): void {
+		const itemGroup = this.getItemsArray().at(itemIndex) as FormGroup;
+		const sku: string = itemGroup.get('sku')?.value || '';
+		const alloc = this.getAllocationsArray(itemIndex).at(allocIndex) as FormGroup;
+		const loc: string = alloc.get('location')?.value || '';
+		if (sku && loc) {
+			this.loadAvailableQtyForAlloc(itemIndex, allocIndex, sku, loc);
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Start Picking (lazy reservation — B3a)
+	// ─────────────────────────────────────────────────────────────
+
+	async startPicking(): Promise<void> {
+		if (!this.task) return;
+		try {
+			this.loadingService.show();
+			const response = await this.pickingTaskService.start(this.task.id);
+			if (response.result.success) {
+				this.alertService.success(
+					this.t('picking_started_successfully') || 'Picking iniciado. Stock reservado.',
+					this.t('success')
+				);
+				this.success.emit();
+			} else {
+				const msg = response.result.message || '';
+				this.alertService.error(
+					humanizeApiError(msg, this.t, 'failed_to_start_picking'),
+					this.t('error')
+				);
+			}
+		} catch (error: any) {
+			this.alertService.error(
+				getDisplayableApiError(error, this.t, 'error_starting_picking'),
+				this.t('error')
+			);
+		} finally {
+			this.loadingService.hide();
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Operator Combobox
+	// ─────────────────────────────────────────────────────────────
+
 	isOperatorValid(): boolean {
 		const formValue = this.form.get('assigned_to')?.value;
 		return !!formValue && this.users.some(u => u.id === formValue);
@@ -145,16 +389,15 @@ export class PickingTaskFormComponent implements OnInit {
 		setTimeout(() => (this.showOperatorDropdown = false), 150);
 	}
 
-	// Operator combobox methods
 	filterOperators(): void {
 		const term = (this.operatorSearchTerm || '').toLowerCase();
 		if (!term) {
 			this.filteredOperators = [...this.users];
 			return;
 		}
-		this.filteredOperators = this.users.filter(user => 
-			(user.first_name || '').toLowerCase().includes(term) || 
-			(user.last_name || '').toLowerCase().includes(term) || 
+		this.filteredOperators = this.users.filter(user =>
+			(user.first_name || '').toLowerCase().includes(term) ||
+			(user.last_name || '').toLowerCase().includes(term) ||
 			(user.email || '').toLowerCase().includes(term)
 		);
 	}
@@ -174,38 +417,32 @@ export class PickingTaskFormComponent implements OnInit {
 		if (list.length > 0) this.onOperatorSelected(list[0]);
 	}
 
+	// ─────────────────────────────────────────────────────────────
+	//  Data Loading
+	// ─────────────────────────────────────────────────────────────
+
 	async loadData(): Promise<void> {
 		try {
 			this.isLoading = true;
-			
-			// Load data in parallel (locations, users, articles)
 			const [locationResponse, userResponse, articleResponse] = await Promise.all([
 				this.locationService.getAll(),
 				this.userService.getAll(),
 				this.articleService.getAll()
 			]);
-
 			if (locationResponse.result.success) {
 				this.locations = locationResponse.data;
 			}
-
 			if (userResponse.result.success) {
-				// Only operators
 				this.users = (userResponse.data || []).filter(
 					(u: User) => (u.role?.name ?? u.role_id ?? '').toLowerCase() === 'operator'
 				);
 				this.filteredOperators = [...this.users];
 			}
-
 			if (articleResponse.result.success) {
-				// Solo mostrar artículos activos
-				this.articles = (articleResponse.data || []).filter(article => article.is_active !== false);
+				this.articles = (articleResponse.data || []).filter(a => a.is_active !== false);
 			}
-		} catch (error) {
-			this.alertService.error(
-				this.t('error_loading_data'),
-				this.t('error')
-			);
+		} catch {
+			this.alertService.error(this.t('error_loading_data'), this.t('error'));
 		} finally {
 			this.isLoading = false;
 		}
@@ -213,16 +450,10 @@ export class PickingTaskFormComponent implements OnInit {
 
 	loadTaskForEdit(): void {
 		if (!this.task) return;
-		
-		// Inicializar el campo de operador
+
 		if (this.task.assigned_to) {
 			const user = this.users.find(u => u.id === this.task!.assigned_to);
-			if (user) {
-				this.operatorSearchTerm = this.getUserDisplayName(user.id);
-			} else {
-				// Si no encuentra el usuario, mostrar el ID
-				this.operatorSearchTerm = this.task.assigned_to;
-			}
+			this.operatorSearchTerm = user ? this.getUserDisplayName(user.id) : this.task.assigned_to;
 		}
 
 		this.form.patchValue({
@@ -232,66 +463,55 @@ export class PickingTaskFormComponent implements OnInit {
 			notes: this.task.notes || ''
 		});
 
-		// Limpiar items existentes
 		while (this.itemsArray.length !== 0) {
 			this.itemsArray.removeAt(0);
 		}
 
 		if (this.task.items && this.task.items.length > 0) {
 			this.task.items.forEach((item, i) => {
-				// Mapear campos del backend a frontend
-				const lotNumbers = item.lotNumbers || item.lot_numbers || [];
-				const serialNumbers = item.serialNumbers || item.serial_numbers || [];
 				const requiredQty = item.expectedQty || item.required_qty || 0;
-				
-				this.itemsArray.push(this.fb.group({
-					sku: [item.sku, [Validators.required]],
-					location: [item.location, [Validators.required]],
-					lot_numbers: [lotNumbers?.join(', ') || ''],
-					serial_numbers: [serialNumbers?.join(', ') || '']
-				}));
-				
-				// Asegurar que la cantidad requerida se carga correctamente
-				this.requiredQuantities[i] = requiredQty;
-				
+
+				// Use allocations if present; fall back to legacy location field (F0 alias)
+				const allocations: LocationAllocation[] =
+					(item.allocations || []).length > 0
+						? item.allocations
+						: (item.location ? [{ location: item.location, quantity: requiredQty }] : []);
+
+				const itemGroup = this.createItemGroup({ sku: item.sku, required_qty: requiredQty, allocations });
+				this.itemsArray.push(itemGroup);
 				this.ensureComboboxState(i);
-				
-				// Cargar términos de búsqueda para mostrar nombres descriptivos
-				const article = this.getArticleBySku(item.sku);
+
+				const article = this.articles.find(a => a.sku === item.sku);
 				this.skuSearchTerms[i] = article ? `${article.sku} - ${article.name}` : item.sku;
-				
-				const loc = this.locations.find(l => l.location_code === item.location);
-				this.locationSearchTerms[i] = loc ? `${loc.location_code} - ${loc.description}` : item.location;
-				
-				// Cargar opciones de tracking (lotes y series)
-				this.loadTrackingOptionsForItem(i, item.sku);
+
+				// Load F3 available qty for each allocation
+				allocations.forEach((alloc, j) => {
+					if (item.sku && alloc.location) {
+						this.loadAvailableQtyForAlloc(i, j, item.sku, alloc.location);
+					}
+				});
 			});
 		} else {
 			this.addItem();
 		}
-		
-		// Forzar detección de cambios
+
 		this.cdr.detectChanges();
 	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Item Management
+	// ─────────────────────────────────────────────────────────────
 
 	get itemsArray(): FormArray {
 		return this.form.get('items') as FormArray;
 	}
 
 	canAddItem(): boolean {
-		if (this.itemsArray.length === 0) {
-			return true;
-		}
-
-		const lastItem = this.itemsArray.at(this.itemsArray.length - 1);
-		if (!lastItem) return true;
-
-		const lastIndex = this.itemsArray.length - 1;
-		const sku = lastItem.get('sku')?.value;
-		const requiredQty = this.requiredQuantities[lastIndex];
-		const location = lastItem.get('location')?.value;
-
-		return !!(sku && requiredQty && requiredQty > 0 && location);
+		if (this.itemsArray.length === 0) return true;
+		const last = this.itemsArray.at(this.itemsArray.length - 1) as FormGroup;
+		const sku: string = last.get('sku')?.value || '';
+		const qty = Number(last.get('required_qty')?.value);
+		return !!(sku && qty > 0);
 	}
 
 	addItem(): void {
@@ -302,21 +522,10 @@ export class PickingTaskFormComponent implements OnInit {
 			);
 			return;
 		}
-
-		const itemGroup = this.fb.group({
-			sku: ['', [Validators.required]],
-			location: ['', [Validators.required]],
-			lot_numbers: [''],
-			serial_numbers: ['']
-		});
-
+		const itemGroup = this.createItemGroup();
 		this.itemsArray.push(itemGroup);
-
 		const index = this.itemsArray.length - 1;
-		this.requiredQuantities[index] = 1; // Inicializar con 1 en lugar de 0
 		this.ensureComboboxState(index);
-		
-		// Forzar detección de cambios para que se rendericen correctamente los campos
 		this.cdr.detectChanges();
 	}
 
@@ -324,157 +533,51 @@ export class PickingTaskFormComponent implements OnInit {
 		if (this.itemsArray.length > 1) {
 			this.itemsArray.removeAt(index);
 			this.skuSearchTerms.splice(index, 1);
-			this.locationSearchTerms.splice(index, 1);
 			this.showSkuDropdown.splice(index, 1);
-			this.showLocationDropdown.splice(index, 1);
 			this.filteredArticlesPerItem.splice(index, 1);
-			this.filteredLocationsPerItem.splice(index, 1);
-			this.requiredQuantities.splice(index, 1);
-			this.availableLotsPerItem.splice(index, 1);
-			this.availableSerialsPerItem.splice(index, 1);
-			this.filteredLotsPerItem.splice(index, 1);
-			this.filteredSerialsPerItem.splice(index, 1);
-			this.pickSuggestionsPerItem.splice(index, 1);
-			this.lotSearchTerms.splice(index, 1);
-			this.serialSearchTerms.splice(index, 1);
-			this.showLotDropdown.splice(index, 1);
-			this.showSerialDropdown.splice(index, 1);
-		}
-	}
-
-	async onSubmit(): Promise<void> {
-		if (this.form.invalid || !this.isFormComplete()) {
-			this.markFormGroupTouched(this.form);
-			this.alertService.error(
-				this.t('please_complete_required_fields'),
-				this.t('error')
-			);
-			return;
-		}
-
-		try {
-			this.loadingService.show();
-			
-			const formValue = this.form.value;
-			const taskData: any = {
-				outbound_number: formValue.outbound_number,
-				assigned_to: formValue.assigned_to,
-				priority: formValue.priority,
-				status: this.task ? this.task.status : 'open',
-				items: formValue.items.map((item: any, index: number) => ({
-					sku: item.sku,
-					required_qty: this.requiredQuantities[index] || 0,
-					location: item.location,
-					lot_numbers: item.lot_numbers ? item.lot_numbers.split(',').map((s: string) => s.trim()).filter((s: string) => s) : undefined,
-					serial_numbers: item.serial_numbers ? item.serial_numbers.split(',').map((s: string) => s.trim()).filter((s: string) => s) : undefined
-				}))
-			};
-
-
-			if (formValue.notes && formValue.notes.trim() !== '') {
-				taskData.notes = formValue.notes;
+			// Clear warnings and cached available qty (re-indexed on next access)
+			const updated: Record<string, number> = {};
+			for (const [key, val] of Object.entries(this.availableQtyPerAlloc)) {
+				const ki = Number(key.split('-')[0]);
+				if (ki < index) updated[key] = val;
+				else if (ki > index) {
+					const ji = key.split('-')[1];
+					updated[`${ki - 1}-${ji}`] = val;
+				}
 			}
-			
-
-		if (this.task) {
-			const response = await this.pickingTaskService.update(this.task.id, taskData);
-			if (response.result.success) {
-				this.alertService.success(
-					this.t('picking_task_updated_successfully'),
-					this.t('success')
-				);
-				this.success.emit();
-			} else {
-				const msg = response.result.message || '';
-				this.alertService.error(
-					humanizeApiError(msg, this.t, 'failed_to_update_picking_task'),
-					this.t('error')
-				);
+			this.availableQtyPerAlloc = updated;
+			const updatedWarnings: Record<number, string> = {};
+			for (const [ki, msg] of Object.entries(this.stockWarnings)) {
+				const n = Number(ki);
+				if (n < index) updatedWarnings[n] = msg;
+				else if (n > index) updatedWarnings[n - 1] = msg;
 			}
-		} else {
-			const response = await this.pickingTaskService.create(taskData);
-			if (response.result.success) {
-				this.alertService.success(
-					this.t('picking_task_created_successfully'),
-					this.t('success')
-				);
-				this.success.emit();
-			} else {
-				const msg = response.result.message || '';
-				this.alertService.error(
-					humanizeApiError(msg, this.t, 'failed_to_create_picking_task'),
-					this.t('error')
-				);
-			}
-		}
-		} catch (error: any) {
-			this.alertService.error(
-				getDisplayableApiError(error, this.t, 'error_saving_task'),
-				this.t('error')
-			);
-		} finally {
-			this.loadingService.hide();
+			this.stockWarnings = updatedWarnings;
 		}
 	}
 
 	ensureComboboxState(index: number): void {
 		if (this.skuSearchTerms[index] === undefined) this.skuSearchTerms[index] = '';
-		if (this.locationSearchTerms[index] === undefined) this.locationSearchTerms[index] = '';
 		if (this.showSkuDropdown[index] === undefined) this.showSkuDropdown[index] = false;
-		if (this.showLocationDropdown[index] === undefined) this.showLocationDropdown[index] = false;
-		
 		this.filteredArticlesPerItem[index] = [...this.articles];
-		this.filterLocationsForItem(index);
-
-		if (!this.availableLotsPerItem[index]) this.availableLotsPerItem[index] = [];
-		if (!this.availableSerialsPerItem[index]) this.availableSerialsPerItem[index] = [];
-		if (!this.filteredLotsPerItem[index]) this.filteredLotsPerItem[index] = [];
-		if (!this.filteredSerialsPerItem[index]) this.filteredSerialsPerItem[index] = [];
-		if (!this.pickSuggestionsPerItem[index]) this.pickSuggestionsPerItem[index] = [];
-		if (this.lotSearchTerms[index] === undefined) this.lotSearchTerms[index] = '';
-		if (this.serialSearchTerms[index] === undefined) this.serialSearchTerms[index] = '';
-		if (this.showLotDropdown[index] === undefined) this.showLotDropdown[index] = false;
-		if (this.showSerialDropdown[index] === undefined) this.showSerialDropdown[index] = false;
 	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  SKU Combobox
+	// ─────────────────────────────────────────────────────────────
 
 	filterArticlesForItem(index: number): void {
 		const term = (this.skuSearchTerms[index] || '').toLowerCase();
-		if (!term) {
-			this.filteredArticlesPerItem[index] = [...this.articles];
-			return;
-		}
-		this.filteredArticlesPerItem[index] = this.articles.filter(a =>
-			(a.sku || '').toLowerCase().includes(term) || (a.name || '').toLowerCase().includes(term)
-		);
-	}
-
-	filterLocationsForItem(index: number): void {
-		const term = (this.locationSearchTerms[index] || '').toLowerCase();
-		let list = term
-			? this.locations.filter(l =>
-					(l.location_code || '').toLowerCase().includes(term) || (l.description || '').toLowerCase().includes(term)
+		this.filteredArticlesPerItem[index] = term
+			? this.articles.filter(a =>
+					(a.sku || '').toLowerCase().includes(term) || (a.name || '').toLowerCase().includes(term)
 				)
-			: [...this.locations];
-		// Sort by pick suggestions order (rotation + lowest qty first) when available
-		const suggestions = this.pickSuggestionsPerItem[index] || [];
-		if (suggestions.length > 0) {
-			const order = [...new Set(suggestions.map(s => s.location))];
-			list = list.slice().sort((a, b) => {
-				const ia = order.indexOf(a.location_code);
-				const ib = order.indexOf(b.location_code);
-				if (ia === -1 && ib === -1) return 0;
-				if (ia === -1) return 1;
-				if (ib === -1) return -1;
-				return ia - ib;
-			});
-		}
-		this.filteredLocationsPerItem[index] = list;
+			: [...this.articles];
 	}
 
-	// SKU dropdown validation and advanced methods
 	isSkuValid(index: number): boolean {
-		const formValue = this.itemsArray.at(index).get('sku')?.value;
-		return !!formValue && this.articles.some(a => a.sku === formValue);
+		const sku = this.itemsArray.at(index).get('sku')?.value;
+		return !!sku && this.articles.some(a => a.sku === sku);
 	}
 
 	hasValidSkuSelection(index: number): boolean {
@@ -485,14 +588,14 @@ export class PickingTaskFormComponent implements OnInit {
 		this.skuSearchTerms[index] = '';
 		this.showSkuDropdown[index] = true;
 		this.itemsArray.at(index).get('sku')?.setValue('');
-		this.clearItemTrackingData(index);
 	}
 
 	clearSkuManually(index: number): void {
 		this.skuSearchTerms[index] = '';
 		this.itemsArray.at(index).get('sku')?.setValue('');
 		this.showSkuDropdown[index] = false;
-		this.clearItemTrackingData(index);
+		this.getAllocationsArray(index).clear();
+		delete this.stockWarnings[index];
 	}
 
 	getSelectedSkuName(index: number): string {
@@ -506,489 +609,123 @@ export class PickingTaskFormComponent implements OnInit {
 	}
 
 	onSkuSelected(index: number, article: Article): void {
-		this.clearItemTrackingData(index);
-		
 		this.itemsArray.at(index).get('sku')?.setValue(article.sku);
 		this.skuSearchTerms[index] = `${article.sku} - ${article.name}`;
 		this.showSkuDropdown[index] = false;
-		
-		this.itemsArray.at(index).get('location')?.setValue('');
-		this.locationSearchTerms[index] = '';
-		
-		this.loadTrackingOptionsForItem(index, article.sku);
-	}
-
-	clearItemTrackingData(index: number): void {
-		this.itemsArray.at(index).get('lot_numbers')?.setValue('');
-		this.itemsArray.at(index).get('serial_numbers')?.setValue('');
-
-		this.availableLotsPerItem[index] = [];
-		this.availableSerialsPerItem[index] = [];
-		this.filteredLotsPerItem[index] = [];
-		this.filteredSerialsPerItem[index] = [];
-		this.pickSuggestionsPerItem[index] = [];
-		this.lotSearchTerms[index] = '';
-		this.serialSearchTerms[index] = '';
-		this.showLotDropdown[index] = false;
-		this.showSerialDropdown[index] = false;
-	}
-
-	// Location dropdown validation and advanced methods
-	isLocationValid(index: number): boolean {
-		const formValue = this.itemsArray.at(index).get('location')?.value;
-		return !!formValue && this.locations.some(l => l.location_code === formValue);
-	}
-
-	hasValidLocationSelection(index: number): boolean {
-		return this.isLocationValid(index);
-	}
-
-	enableLocationEdit(index: number): void {
-		this.locationSearchTerms[index] = '';
-		this.showLocationDropdown[index] = true;
-		this.itemsArray.at(index).get('location')?.setValue('');
-	}
-
-	clearLocationManually(index: number): void {
-		this.locationSearchTerms[index] = '';
-		this.itemsArray.at(index).get('location')?.setValue('');
-		this.showLocationDropdown[index] = false;
-	}
-
-	getSelectedLocationName(index: number): string {
-		const locationCode = this.itemsArray.at(index).get('location')?.value;
-		const location = this.locations.find(l => l.location_code === locationCode);
-		return location ? `${location.location_code} - ${location.description}` : '';
-	}
-
-	onLocationBlur(index: number): void {
-		setTimeout(() => (this.showLocationDropdown[index] = false), 150);
-	}
-
-	onLocationSelected(index: number, location: Location): void {
-		this.itemsArray.at(index).get('location')?.setValue(location.location_code);
-		this.locationSearchTerms[index] = `${location.location_code} - ${location.description}`;
-		this.showLocationDropdown[index] = false;
+		// Clear existing allocations for this item
+		this.getAllocationsArray(index).clear();
+		delete this.stockWarnings[index];
+		// Trigger prefill if required_qty is already set
+		this.onSkuOrQtyChange(index);
 	}
 
 	closeSkuDropdownLater(index: number): void {
 		setTimeout(() => (this.showSkuDropdown[index] = false), 150);
 	}
 
-	closeLocationDropdownLater(index: number): void {
-		setTimeout(() => (this.showLocationDropdown[index] = false), 150);
-	}
-
 	confirmFirstArticleIfAny(index: number): void {
 		const list = this.filteredArticlesPerItem[index] || [];
-		if (list.length > 0) {
-			this.onSkuSelected(index, list[0]);
+		if (list.length > 0) this.onSkuSelected(index, list[0]);
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	//  Submit
+	// ─────────────────────────────────────────────────────────────
+
+	async onSubmit(): Promise<void> {
+		if (!this.canSubmit()) {
+			this.markFormGroupTouched(this.form);
+			this.alertService.error(
+				this.t('please_complete_required_fields'),
+				this.t('error')
+			);
+			return;
 		}
-	}
 
-	confirmFirstLocationIfAny(index: number): void {
-		const list = this.filteredLocationsPerItem[index] || [];
-		if (list.length > 0) {
-			this.onLocationSelected(index, list[0]);
-		}
-	}
-
-	private getArticleBySku(sku: string): Article | undefined {
-		return this.articles.find(a => a.sku === sku);
-	}
-
-	shouldShowLotNumbers(index: number): boolean {
-		const sku = this.itemsArray.at(index).get('sku')?.value;
-		const article = this.getArticleBySku(sku);
-		return !!article?.track_by_lot;
-	}
-
-	shouldShowSerialNumbers(index: number): boolean {
-		const sku = this.itemsArray.at(index).get('sku')?.value;
-		const article = this.getArticleBySku(sku);
-		return !!article?.track_by_serial;
-	}
-
-	isLotSelectionComplete(index: number): boolean {
-		const requiredQty = this.getRequiredQuantity(index);
-		const selectedCount = this.getSelectedLotCount(index);
-		return requiredQty > 0 && selectedCount === requiredQty;
-	}
-
-	isSerialSelectionComplete(index: number): boolean {
-		const requiredQty = this.getRequiredQuantity(index);
-		const selectedCount = this.getSelectedSerialCount(index);
-		return requiredQty > 0 && selectedCount === requiredQty;
-	}
-
-	private async loadTrackingOptionsForItem(index: number, sku: string): Promise<void> {
-		const article = this.getArticleBySku(sku);
-		if (!article) return;
-		// Load pick suggestions (rotation + lowest quantity first) for location/lot ordering
 		try {
-			const suggestionsResp = await this.inventoryService.getPickSuggestions(sku);
-			if (suggestionsResp.result.success && Array.isArray(suggestionsResp.data)) {
-				this.pickSuggestionsPerItem[index] = suggestionsResp.data;
-			} else {
-				this.pickSuggestionsPerItem[index] = [];
+			this.loadingService.show();
+			const formValue = this.form.value;
+
+			const taskData: CreatePickingTaskRequest = {
+				outbound_number: formValue.outbound_number,
+				assigned_to: formValue.assigned_to,
+				priority: formValue.priority,
+				status: this.task ? this.task.status : 'open',
+				items: this.getItemsArray().controls.map((itemCtrl) => {
+					const itemGroup = itemCtrl as FormGroup;
+					const allocsArray = itemGroup.get('allocations') as FormArray;
+					const allocations: LocationAllocation[] = allocsArray.controls.map((allocCtrl) => {
+						const ag = allocCtrl as FormGroup;
+						const alloc: LocationAllocation = {
+							location: ag.get('location')?.value || '',
+							quantity: Number(ag.get('quantity')?.value) || 0,
+						};
+						const lotNum: string = ag.get('lot_number')?.value || '';
+						if (lotNum) alloc.lot_number = lotNum;
+						return alloc;
+					});
+					return {
+						sku: itemGroup.get('sku')?.value as string,
+						required_qty: Number(itemGroup.get('required_qty')?.value) || 0,
+						allocations,
+					};
+				}),
+			};
+
+			if (formValue.notes?.trim()) {
+				taskData.notes = formValue.notes;
 			}
-		} catch {
-			this.pickSuggestionsPerItem[index] = [];
-		}
-		// Re-apply location filter so dropdown shows suggested order
-		this.filterLocationsForItem(index);
-		if (article.track_by_lot) {
-			try {
-				const lotsResp = await this.lotService.getBySku(sku);
-				if (lotsResp.result.success) {
-					this.availableLotsPerItem[index] = (lotsResp.data || []).map(l => l.lot_number);
-					this.filteredLotsPerItem[index] = [...this.availableLotsPerItem[index]];
+
+			if (this.task) {
+				const response = await this.pickingTaskService.update(this.task.id, taskData);
+				if (response.result.success) {
+					this.alertService.success(this.t('picking_task_updated_successfully'), this.t('success'));
+					this.success.emit();
+				} else {
+					this.alertService.error(
+						humanizeApiError(response.result.message || '', this.t, 'failed_to_update_picking_task'),
+						this.t('error')
+					);
 				}
-			} catch {}
-		}
-		if (article.track_by_serial) {
-			try {
-				const serialsResp = await this.serialService.getBySku(sku);
-				if (serialsResp.result.success) {
-					this.availableSerialsPerItem[index] = (serialsResp.data || []).map(s => s.serial_number);
-					this.filteredSerialsPerItem[index] = [...this.availableSerialsPerItem[index]];
+			} else {
+				const response = await this.pickingTaskService.create(taskData);
+				if (response.result.success) {
+					this.alertService.success(this.t('picking_task_created_successfully'), this.t('success'));
+					this.success.emit();
+				} else {
+					this.alertService.error(
+						humanizeApiError(response.result.message || '', this.t, 'failed_to_create_picking_task'),
+						this.t('error')
+					);
 				}
-			} catch {}
-		}
-	}
-
-	filterLotsForItem(index: number): void {
-		const term = (this.lotSearchTerms[index] || '').toLowerCase();
-		const options = this.availableLotsPerItem[index] || [];
-		this.filteredLotsPerItem[index] = term ? options.filter(v => (v || '').toLowerCase().includes(term)) : [...options];
-	}
-
-	filterSerialsForItem(index: number): void {
-		const term = (this.serialSearchTerms[index] || '').toLowerCase();
-		const options = this.availableSerialsPerItem[index] || [];
-		this.filteredSerialsPerItem[index] = term ? options.filter(v => (v || '').toLowerCase().includes(term)) : [...options];
-	}
-
-	onRequiredQuantityChange(index: number): void {
-		const ctrl = this.itemsArray.at(index);
-		if (ctrl) {
-			ctrl.get('lot_numbers')?.setValue('');
-			ctrl.get('serial_numbers')?.setValue('');
-			this.lotSearchTerms[index] = '';
-			this.serialSearchTerms[index] = '';
-			this.showLotDropdown[index] = false;
-			this.showSerialDropdown[index] = false;
-		}
-	}
-
-	getRequiredQuantity(index: number, dato?: number): number {
-		if (dato !== undefined && dato !== null) {
-			return dato;
-		}
-		
-		const qty = this.requiredQuantities[index] || 0;
-		return Number(qty) || 0;
-	}
-
-	getSelectedLots(index: number): string[] {
-		const ctrl = this.itemsArray.at(index).get('lot_numbers');
-		const current = (ctrl?.value as string) || '';
-		return current ? current.split(',').map(s => s.trim()).filter(Boolean) : [];
-	}
-
-	getSelectedLotCount(index: number): number {
-		return this.getSelectedLots(index).length;
-	}
-
-	getSelectedSerials(index: number): string[] {
-		const ctrl = this.itemsArray.at(index).get('serial_numbers');
-		const current = (ctrl?.value as string) || '';
-		return current ? current.split(',').map(s => s.trim()).filter(Boolean) : [];
-	}
-
-	getSelectedSerialCount(index: number): number {
-		return this.getSelectedSerials(index).length;
-	}
-
-	isLotSelected(index: number, lotNumber: string): boolean {
-		return this.getSelectedLots(index).includes(lotNumber);
-	}
-
-	isSerialSelected(index: number, serialNumber: string): boolean {
-		return this.getSelectedSerials(index).includes(serialNumber);
-	}
-
-	onLotSelected(index: number, lotNumber: string): void {
-		const ctrl = this.itemsArray.at(index).get('lot_numbers');
-		const current = this.getSelectedLots(index);
-		const requiredQty = this.getRequiredQuantity(index);
-
-		if (current.includes(lotNumber)) {
-			const updated = current.filter(lot => lot !== lotNumber);
-			ctrl?.setValue(updated.join(', '));
-		} else if (current.length < requiredQty) {
-			current.push(lotNumber);
-			ctrl?.setValue(current.join(', '));
-		} else {
-			this.alertService.warning(
-				this.t('lot_selection_limit_reached'),
-				this.t('warning')
-			);
-		}
-		this.showLotDropdown[index] = false;
-	}
-
-	onSerialSelected(index: number, serialNumber: string): void {
-		const ctrl = this.itemsArray.at(index).get('serial_numbers');
-		const current = this.getSelectedSerials(index);
-		const requiredQty = this.getRequiredQuantity(index);
-
-		if (current.includes(serialNumber)) {
-			const updated = current.filter(serial => serial !== serialNumber);
-			ctrl?.setValue(updated.join(', '));
-		} else if (current.length < requiredQty) {
-			current.push(serialNumber);
-			ctrl?.setValue(current.join(', '));
-		} else {
-			this.alertService.warning(
-				this.t('serial_selection_limit_reached'),
-				this.t('warning')
-			);
-		}
-		this.showSerialDropdown[index] = false;
-	}
-
-	removeLot(index: number, lotNumber: string): void {
-		const ctrl = this.itemsArray.at(index).get('lot_numbers');
-		const current = this.getSelectedLots(index);
-		const updated = current.filter(lot => lot !== lotNumber);
-		ctrl?.setValue(updated.join(', '));
-	}
-
-	removeSerial(index: number, serialNumber: string): void {
-		const ctrl = this.itemsArray.at(index).get('serial_numbers');
-		const current = this.getSelectedSerials(index);
-		const updated = current.filter(serial => serial !== serialNumber);
-		ctrl?.setValue(updated.join(', '));
-	}
-
-	selectRandomLots(index: number): void {
-		const requiredQty = this.getRequiredQuantity(index);
-		const availableLots = this.availableLotsPerItem[index] || [];
-		
-		if (availableLots.length === 0) {
-			this.alertService.warning(
-				this.t('no_lots_available'),
-				this.t('warning')
-			);
-			return;
-		}
-
-		if (requiredQty <= 0) {
-			this.alertService.warning(
-				this.t('set_required_quantity_first'),
-				this.t('warning')
-			);
-			return;
-		}
-
-		// Seleccionar lotes al azar
-		const shuffled = [...availableLots].sort(() => 0.5 - Math.random());
-		const selected = shuffled.slice(0, Math.min(requiredQty, availableLots.length));
-		
-		const ctrl = this.itemsArray.at(index).get('lot_numbers');
-		ctrl?.setValue(selected.join(', '));
-
-		this.alertService.success(
-			this.t('random_lots_selected') + ` (${selected.length})`,
-			this.t('success')
-		);
-	}
-
-	selectRandomSerials(index: number): void {
-		const requiredQty = this.getRequiredQuantity(index);
-		const availableSerials = this.availableSerialsPerItem[index] || [];
-		
-		if (availableSerials.length === 0) {
-			this.alertService.warning(
-				this.t('no_serials_available'),
-				this.t('warning')
-			);
-			return;
-		}
-
-		if (requiredQty <= 0) {
-			this.alertService.warning(
-				this.t('set_required_quantity_first'),
-				this.t('warning')
-			);
-			return;
-		}
-
-		// Seleccionar series al azar
-		const shuffled = [...availableSerials].sort(() => 0.5 - Math.random());
-		const selected = shuffled.slice(0, Math.min(requiredQty, availableSerials.length));
-		
-		const ctrl = this.itemsArray.at(index).get('serial_numbers');
-		ctrl?.setValue(selected.join(', '));
-
-		this.alertService.success(
-			this.t('random_serials_selected') + ` (${selected.length})`,
-			this.t('success')
-		);
-	}
-
-	closeLotDropdownLater(index: number): void {
-		setTimeout(() => (this.showLotDropdown[index] = false), 150);
-	}
-
-	closeSerialDropdownLater(index: number): void {
-		setTimeout(() => (this.showSerialDropdown[index] = false), 150);
-	}
-
-	confirmFirstLotIfAny(index: number): void {
-		const list = this.filteredLotsPerItem[index] || [];
-		if (list.length > 0) this.onLotSelected(index, list[0]);
-	}
-
-	confirmFirstSerialIfAny(index: number): void {
-		const list = this.filteredSerialsPerItem[index] || [];
-		if (list.length > 0) this.onSerialSelected(index, list[0]);
-	}
-
-	// Manual input handlers - allow typing without immediate processing
-	onManualLotInput(index: number): void {
-		// Typing is allowed, processing happens on Enter
-	}
-
-	onManualSerialInput(index: number): void {
-		// Typing is allowed, processing happens on Enter
-	}
-
-	handleLotEnter(index: number): void {
-		const searchTerm = (this.lotSearchTerms[index] || '').trim();
-		if (searchTerm) {
-			// Check if it's from dropdown first
-			const filtered = this.filteredLotsPerItem[index] || [];
-			const exactMatch = filtered.find(lot => lot.toLowerCase() === searchTerm.toLowerCase());
-			
-			if (exactMatch) {
-				// Select from dropdown if exact match
-				this.onLotSelected(index, exactMatch);
-			} else {
-				// Add as manual entry
-				this.addManualLot(index, searchTerm);
 			}
-		}
-	}
-
-	handleSerialEnter(index: number): void {
-		const searchTerm = (this.serialSearchTerms[index] || '').trim();
-		if (searchTerm) {
-			// Check if it's from dropdown first
-			const filtered = this.filteredSerialsPerItem[index] || [];
-			const exactMatch = filtered.find(serial => serial.toLowerCase() === searchTerm.toLowerCase());
-			
-			if (exactMatch) {
-				// Select from dropdown if exact match
-				this.onSerialSelected(index, exactMatch);
-			} else {
-				// Add as manual entry
-				this.addManualSerial(index, searchTerm);
-			}
-		}
-	}
-
-	addManualLot(index: number, lotNumber: string): void {
-		if (!lotNumber.trim()) return;
-		
-		const ctrl = this.itemsArray.at(index).get('lot_numbers');
-		const current = this.getSelectedLots(index);
-		const requiredQty = this.getRequiredQuantity(index);
-
-		if (!current.includes(lotNumber.trim()) && current.length < requiredQty) {
-			current.push(lotNumber.trim());
-			ctrl?.setValue(current.join(', '));
-			this.lotSearchTerms[index] = '';
-			this.showLotDropdown[index] = false;
-		} else if (current.length >= requiredQty) {
-			this.alertService.warning(
-				this.t('lot_selection_limit_reached'),
-				this.t('warning')
+		} catch (error: any) {
+			this.alertService.error(
+				getDisplayableApiError(error, this.t, 'error_saving_task'),
+				this.t('error')
 			);
+		} finally {
+			this.loadingService.hide();
 		}
 	}
 
-	addManualSerial(index: number, serialNumber: string): void {
-		if (!serialNumber.trim()) return;
-		
-		const ctrl = this.itemsArray.at(index).get('serial_numbers');
-		const current = this.getSelectedSerials(index);
-		const requiredQty = this.getRequiredQuantity(index);
-
-		if (!current.includes(serialNumber.trim()) && current.length < requiredQty) {
-			current.push(serialNumber.trim());
-			ctrl?.setValue(current.join(', '));
-			this.serialSearchTerms[index] = '';
-			this.showSerialDropdown[index] = false;
-		} else if (current.length >= requiredQty) {
-			this.alertService.warning(
-				this.t('serial_selection_limit_reached'),
-				this.t('warning')
-			);
-		}
-	}
+	// ─────────────────────────────────────────────────────────────
+	//  Helpers
+	// ─────────────────────────────────────────────────────────────
 
 	getUserDisplayName(userId: string): string {
 		const user = this.users.find(u => u.id === userId);
-		return user ? user.first_name + ' ' + user.last_name || user.email : userId;
+		return user ? `${user.first_name} ${user.last_name}` || user.email : userId;
 	}
 
-	getLocationDisplayName(locationCode: string): string {
-		const location = this.locations.find(l => l.location_code === locationCode);
-		return location ? `${location.location_code}${location.description ? ` - ${location.description}` : ''}` : locationCode;
-	}
-
-	markFormGroupTouched(formGroup: any): void {
-		Object.keys(formGroup.controls).forEach(field => {
-			const control = formGroup.get(field);
+	markFormGroupTouched(fg: any): void {
+		Object.keys(fg.controls).forEach(field => {
+			const control = fg.get(field);
 			control?.markAsTouched({ onlySelf: true });
-			
-			if (control && (control as any).controls) {
+			if (control?.controls) {
 				this.markFormGroupTouched(control);
 			}
 		});
-	}
-
-	isFormComplete(): boolean {
-		for (let i = 0; i < this.itemsArray.length; i++) {
-			const item = this.itemsArray.at(i);
-			const sku = item.get('sku')?.value;
-			const requiredQty = this.requiredQuantities[i] || 0;
-			const location = item.get('location')?.value;
-
-			if (!sku || !requiredQty || requiredQty <= 0 || !location) {
-				return false;
-			}
-
-			const article = this.getArticleBySku(sku);
-			
-			if (article?.track_by_lot) {
-				const selectedLots = this.getSelectedLots(i);
-				if (selectedLots.length !== requiredQty) {
-					return false;
-				}
-			}
-			
-			if (article?.track_by_serial) {
-				const selectedSerials = this.getSelectedSerials(i);
-				if (selectedSerials.length !== requiredQty) {
-					return false;
-				}
-			}
-		}
-
-		return true;
 	}
 
 	isFieldInvalid(fieldName: string): boolean {
@@ -998,48 +735,27 @@ export class PickingTaskFormComponent implements OnInit {
 
 	getFieldError(fieldName: string): string {
 		const field = this.form.get(fieldName);
-		if (field && field.errors && field.touched) {
+		if (field?.errors && field.touched) {
 			if (field.errors['required']) {
 				const key = `${fieldName}_required`;
 				const msg = this.t(key);
 				return msg !== key ? msg : this.t('field_required');
 			}
-			if (field.errors['min']) {
-				return this.t('quantity_min');
-			}
+			if (field.errors['min']) return this.t('quantity_min');
 		}
 		return '';
 	}
 
 	isItemFieldInvalid(itemIndex: number, fieldName: string): boolean {
-		if (fieldName === 'required_qty') {
-			const qty = this.requiredQuantities[itemIndex] || 0;
-			return qty <= 0;
-		}
-		
-		const itemGroup = this.itemsArray.at(itemIndex);
-		const field = itemGroup.get(fieldName);
+		const field = this.itemsArray.at(itemIndex).get(fieldName);
 		return !!(field && field.invalid && field.touched);
 	}
 
 	getItemFieldError(itemIndex: number, fieldName: string): string {
-		if (fieldName === 'required_qty') {
-			const qty = this.requiredQuantities[itemIndex] || 0;
-			if (qty <= 0) {
-				return this.t('required_qty_required');
-			}
-			return '';
-		}
-		
-		const itemGroup = this.itemsArray.at(itemIndex);
-		const field = itemGroup.get(fieldName);
-		if (field && field.errors && field.touched) {
-			if (field.errors['required']) {
-				return this.t(`${fieldName}_required`);
-			}
-			if (field.errors['min']) {
-				return this.t('quantity_min');
-			}
+		const field = this.itemsArray.at(itemIndex).get(fieldName);
+		if (field?.errors && field.touched) {
+			if (field.errors['required']) return this.t(`${fieldName}_required`);
+			if (field.errors['min']) return this.t('quantity_min');
 		}
 		return '';
 	}

--- a/src/app/models/pick-suggestion.model.ts
+++ b/src/app/models/pick-suggestion.model.ts
@@ -1,5 +1,6 @@
 /**
  * Suggested pick for outbound: location + lot + quantity, sorted by rotation (FIFO/FEFO) then lowest quantity first.
+ * @deprecated H3 rewrite returns PickSuggestionResponse instead. Kept for legacy fallback handling.
  */
 export interface PickSuggestion {
 	location: string;
@@ -8,4 +9,26 @@ export interface PickSuggestion {
 	quantity: number;
 	expiration_date?: string | null;
 	lot_created_at: string;
+}
+
+/**
+ * One allocation within a PickSuggestionResponse — maps to LocationAllocation shape.
+ * expiration_date is display-only; not sent back to backend.
+ */
+export interface AllocationSuggestion {
+	location: string;
+	quantity: number;
+	lot_number?: string;
+	expiration_date?: string;
+}
+
+/**
+ * Response from GET /inventory/pick-suggestions/:sku?qty=N (H3 FEFO rewrite).
+ * allocations are pre-sorted FEFO across all locations.
+ */
+export interface PickSuggestionResponse {
+	allocations: AllocationSuggestion[];
+	total_found: number;
+	requested: number;
+	sufficient: boolean;
 }

--- a/src/app/services/inventory.service.ts
+++ b/src/app/services/inventory.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ApiResponse } from '@app/models';
 import { Inventory, CreateInventoryRequest, UpdateInventoryRequest } from '@app/models/inventory.model';
-import { PickSuggestion } from '@app/models/pick-suggestion.model';
+import { PickSuggestionResponse } from '@app/models/pick-suggestion.model';
 import { returnCompleteURI } from '@app/utils';
 import { environment } from '@environment';
 import { FetchService } from './extras/fetch.service';
@@ -29,11 +29,13 @@ export class InventoryService {
 	}
 
 	/**
-	 * @description Get pick suggestions for a SKU: locations and lots sorted by rotation (FIFO/FEFO) then lowest quantity first.
+	 * Get FEFO pick suggestions for a SKU across all locations (H3 rewrite).
+	 * @param qty Optional required quantity — backend greedy-allocates across locations.
 	 */
-	async getPickSuggestions(sku: string): Promise<ApiResponse<PickSuggestion[]>> {
-		return await this.fetchService.get<ApiResponse<PickSuggestion[]>>({
-			API_Gateway: `${INVENTORY_URL}/pick-suggestions/${encodeURIComponent(sku)}`,
+	async getPickSuggestions(sku: string, qty?: number): Promise<ApiResponse<PickSuggestionResponse>> {
+		const qtyParam = qty !== undefined ? `?qty=${qty}` : '';
+		return await this.fetchService.get<ApiResponse<PickSuggestionResponse>>({
+			API_Gateway: `${INVENTORY_URL}/pick-suggestions/${encodeURIComponent(sku)}${qtyParam}`,
 		});
 	}
 


### PR DESCRIPTION
## Summary

- **F2**: Replaces single-location field with FormArray `allocations` per item. SKU + required_qty change → auto-calls `GET /inventory/pick-suggestions/:sku?qty=N` → pre-fills allocations from FEFO response. Allocation sum validation blocks submit if `sum(alloc.qty) !== required_qty`. Stock warning if `sufficient=false`.
- **F3**: Per-allocation `available_qty` indicator via `GET /inventory/by-sku-location/:sku/:location`. Color-coded green (OK) / red (insufficient). Loads on prefill and on location blur.
- **Start picking**: "Iniciar picking" button (visible when editing, status = `open|assigned`) calls `POST /picking-tasks/:id/start` (backend B3a). On error shows backend message (e.g. "Stock insuficiente…").
- **TS fix**: Resolves downstream TS2322 error from F0 (`item.location: string|undefined` at picking-task-form:264). Legacy tasks with `location` field get a synthetic single-allocation fallback.
- **Models**: Adds `PickSuggestionResponse + AllocationSuggestion` (H3 contract). Updates `getPickSuggestions(sku, qty?)`.

## Test plan

- [ ] `ng build --configuration=development` — 0 errors ✅
- [ ] 9 Jasmine specs in `picking-task-form.component.spec.ts` cover: FormArray add/remove, sum validation match/mismatch, FEFO prefill, insufficient warning, available qty green/red, start picking call + error alert
- [ ] Manual smoke: SKU + qty → allocations pre-filled; change alloc location → available qty updates; insufficient → red + warning; sum mismatch → submit disabled; "Iniciar picking" → status `in_progress`

See plans/sessions/2026-04-15-block-F2-F3.md