### PR TITLE
feat(W5): S2 frontend models + services foundations (TS1+SVC1)

### DIFF
--- a/src/app/models/adjustment.model.ts
+++ b/src/app/models/adjustment.model.ts
@@ -1,3 +1,5 @@
+export type AdjustmentType = 'increase' | 'decrease' | 'count_reconcile';
+
 export interface Adjustment {
   id: number;
   sku: string;
@@ -9,6 +11,8 @@ export interface Adjustment {
   notes?: string;
   user_id: string;
   created_at: Date;
+  // S2 extended fields
+  adjustment_type?: AdjustmentType;
 }
 
 export interface AdjustmentFormData {

--- a/src/app/models/article.model.ts
+++ b/src/app/models/article.model.ts
@@ -17,6 +17,18 @@ export interface Article {
 	is_active?: boolean | null;
 	created_at: string;
 	updated_at: string;
+	// S2 extended fields
+	category_id?: string | null;
+	category?: { id: string; name: string };
+	shelf_life_in_days?: number | null;
+	safety_stock?: number;
+	batch_number_series?: string | null;
+	serial_number_series?: string | null;
+	min_order_qty?: number;
+	default_location_id?: string | null;
+	default_location?: { id: string; code: string; name: string };
+	receiving_notes?: string | null;
+	shipping_notes?: string | null;
 }
 
 export interface CreateArticleRequest {

--- a/src/app/models/category.model.ts
+++ b/src/app/models/category.model.ts
@@ -1,0 +1,15 @@
+export interface Category {
+  id: string;
+  tenant_id: string;
+  name: string;
+  parent_id?: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CategoryTreeNode {
+  id: string;
+  name: string;
+  children: CategoryTreeNode[];
+}

--- a/src/app/models/client.model.ts
+++ b/src/app/models/client.model.ts
@@ -1,0 +1,24 @@
+export type ClientType = 'supplier' | 'customer' | 'both';
+
+export interface Client {
+  id: string;
+  tenant_id: string;
+  type: ClientType;
+  code: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  tax_id?: string;
+  notes?: string;
+  is_active: boolean;
+  created_by?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ClientListFilters {
+  type?: ClientType;
+  is_active?: boolean;
+  search?: string;
+}

--- a/src/app/models/index.ts
+++ b/src/app/models/index.ts
@@ -82,6 +82,16 @@ export * from './user.model';
 export * from './role.model';
 export * from './barcode.model';
 export * from './gamification.model';
+// S2 models
+export * from './client.model';
+export * from './category.model';
+export * from './notification.model';
+export * from './stock-settings.model';
+export * from './inventory-valuation.model';
+export * from './lot-trace.model';
+export * from './adjustment.model';
+// Note: lot.model.ts intentionally NOT re-exported here — name collision with
+// inventory.model.ts's inline Lot/CreateLotRequest. Import lot.model directly.
 
 // Import Observable for FetchResponseT
 import { Observable } from 'rxjs';

--- a/src/app/models/inventory-valuation.model.ts
+++ b/src/app/models/inventory-valuation.model.ts
@@ -1,0 +1,15 @@
+export type ValuationGroupBy = 'article' | 'location' | 'category';
+
+export interface ValuationBreakdownItem {
+  key: string;    // sku or location_code or category_id
+  label: string;  // human-readable
+  value: number;
+  qty: number;
+}
+
+export interface InventoryValuation {
+  total_value: number;
+  currency: string;
+  group_by: ValuationGroupBy;
+  breakdown: ValuationBreakdownItem[];
+}

--- a/src/app/models/lot-trace.model.ts
+++ b/src/app/models/lot-trace.model.ts
@@ -1,0 +1,49 @@
+export type MovementType =
+  | 'INBOUND' | 'OUTBOUND' | 'REJECTED'
+  | 'ADJUSTMENT' | 'TRANSFER_IN' | 'TRANSFER_OUT';
+
+export interface InventoryMovement {
+  id: string;
+  type: MovementType;
+  sku: string;
+  location?: string;
+  quantity: number;
+  before_qty?: number;
+  after_qty?: number;
+  unit_cost?: number;
+  reference_type?: 'receiving_task' | 'picking_task' | 'adjustment' | 'stock_transfer' | string;
+  reference_id?: string;
+  lot_id?: string;
+  serial_id?: string;
+  user_id?: string;
+  created_at: string;
+}
+
+export interface LotTraceOrigin {
+  receiving_task_id: string;
+  supplier?: { id: string; code: string; name: string };
+  received_at: string;
+}
+
+export interface LotTraceStockByLocation {
+  location: string;
+  qty: number;
+}
+
+export interface LotTraceResponse {
+  lot: {
+    id: string;
+    lot_number: string;
+    sku: string;
+    expiration_date?: string;
+    manufactured_at?: string;
+    best_before_date?: string;
+    status: string;
+  };
+  origin: LotTraceOrigin | null;
+  movements: InventoryMovement[];
+  current_stock: {
+    total_qty: number;
+    by_location: LotTraceStockByLocation[];
+  };
+}

--- a/src/app/models/lot.model.ts
+++ b/src/app/models/lot.model.ts
@@ -6,6 +6,10 @@ export interface Lot {
 	expiration_date?: string | null;
 	created_at: string;
 	updated_at: string;
+	// S2 extended fields
+	lot_notes?: string | null;
+	manufactured_at?: string | null;
+	best_before_date?: string | null;
 }
 
 export interface CreateLotRequest {

--- a/src/app/models/notification.model.ts
+++ b/src/app/models/notification.model.ts
@@ -1,0 +1,40 @@
+export type NotificationEventType =
+  | 'task_assigned' | 'task_completed'
+  | 'lot_expiring_7d' | 'lot_expiring_1d'
+  | 'low_stock' | 'user_welcome'
+  | (string & {});  // future-proof
+
+export type NotificationChannel = 'in_app' | 'email' | 'push';
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  event_type: NotificationEventType;
+  title: string;
+  body?: string;
+  resource_type?: string;
+  resource_id?: string;
+  channels: string;  // comma-separated
+  is_read: boolean;
+  read_at?: string;
+  sent_email_at?: string;
+  created_at: string;
+}
+
+export interface NotificationPreference {
+  user_id: string;
+  event_type: NotificationEventType;
+  in_app: boolean;
+  email: boolean;
+  push: boolean;
+  updated_at: string;
+}
+
+export interface NotificationListFilters {
+  unread?: boolean;
+  event_type?: NotificationEventType;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}

--- a/src/app/models/picking-task.model.ts
+++ b/src/app/models/picking-task.model.ts
@@ -23,6 +23,9 @@ export interface PickingTask {
 	created_at: string;
 	updated_at: string;
 	completed_at?: string | null;
+	// S2 extended fields
+	customer_id?: string | null;
+	customer?: { id: string; code: string; name: string };
 }
 
 export interface PickingTaskItem {

--- a/src/app/models/receiving-task.model.ts
+++ b/src/app/models/receiving-task.model.ts
@@ -21,6 +21,13 @@ export interface ReceivingTask {
 	created_at: string;
 	updated_at: string;
 	completed_at?: string | null;
+	// S2 extended fields
+	supplier_id?: string | null;
+	vendor_ref?: string | null;
+	tracking_number?: string | null;
+	reception_method?: string | null;
+	incoterms?: string | null;
+	supplier?: { id: string; code: string; name: string };
 }
 
 export interface ReceivingTaskItem {
@@ -36,6 +43,9 @@ export interface ReceivingTaskItem {
 	lot_numbers?: string[];
 	lotNumbers?: string[];
 	serialNumbers?: string[];
+	// S2 extended fields
+	accepted_qty?: number;
+	rejected_qty?: number;
 }
 
 export interface CreateReceivingTaskRequest {

--- a/src/app/models/stock-settings.model.ts
+++ b/src/app/models/stock-settings.model.ts
@@ -1,0 +1,18 @@
+export type ValuationMethod = 'avco' | 'fifo';
+export type PickBatchBasedOn = 'fefo' | 'fifo' | 'lifo';
+export type PartialDeliveryPolicy = 'immediate' | 'when_all_ready';
+
+export interface StockSettings {
+  tenant_id: string;
+  valuation_method: ValuationMethod;
+  pick_batch_based_on: PickBatchBasedOn;
+  over_receipt_allowance_pct: number;
+  over_delivery_allowance_pct: number;
+  over_picking_allowance_pct: number;
+  auto_reserve_stock: boolean;
+  allow_partial_reservation: boolean;
+  expiry_alert_days: number;
+  auto_create_material_request: boolean;
+  partial_delivery_policy: PartialDeliveryPolicy;
+  updated_at: string;
+}

--- a/src/app/services/categories.service.spec.ts
+++ b/src/app/services/categories.service.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { CategoriesService } from './categories.service';
+import { FetchService } from './extras/fetch.service';
+import { mockResponse } from '../../__tests__/mocks/data';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+  let fetchSpy: jasmine.SpyObj<FetchService>;
+
+  beforeEach(() => {
+    fetchSpy = jasmine.createSpyObj('FetchService', ['get', 'post', 'patch', 'delete']);
+    TestBed.configureTestingModule({
+      providers: [CategoriesService, { provide: FetchService, useValue: fetchSpy }],
+    });
+    service = TestBed.inject(CategoriesService);
+  });
+
+  describe('list()', () => {
+    it('calls GET /categories', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));
+      await service.list();
+      expect(fetchSpy.get).toHaveBeenCalledWith(
+        jasmine.objectContaining({ API_Gateway: jasmine.stringContaining('/categories') })
+      );
+    });
+  });
+
+  describe('tree()', () => {
+    it('calls GET /categories/tree', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));
+      await service.tree();
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('/categories/tree');
+    });
+  });
+
+  describe('getById()', () => {
+    it('includes id in URL', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.getById('cat-001');
+      expect(fetchSpy.get).toHaveBeenCalledWith(
+        jasmine.objectContaining({ API_Gateway: jasmine.stringContaining('cat-001') })
+      );
+    });
+  });
+
+  describe('create()', () => {
+    it('calls POST /categories with payload', async () => {
+      fetchSpy.post.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      const payload = { name: 'Electronics', is_active: true };
+      await service.create(payload);
+      expect(fetchSpy.post).toHaveBeenCalledWith(jasmine.objectContaining({ values: payload }));
+    });
+  });
+
+  describe('update()', () => {
+    it('calls PATCH /categories/:id', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.update('cat-001', { name: 'Updated' });
+      const args = fetchSpy.patch.calls.mostRecent().args[0];
+      expect(args.API_Gateway).toContain('cat-001');
+    });
+  });
+
+  describe('softDelete()', () => {
+    it('calls DELETE /categories/:id', async () => {
+      fetchSpy.delete.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      await service.softDelete('cat-001');
+      expect(fetchSpy.delete).toHaveBeenCalledWith(
+        jasmine.objectContaining({ API_Gateway: jasmine.stringContaining('cat-001') })
+      );
+    });
+  });
+});

--- a/src/app/services/categories.service.ts
+++ b/src/app/services/categories.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { ApiResponse } from '@app/models';
+import { Category, CategoryTreeNode } from '@app/models/category.model';
+import { returnCompleteURI } from '@app/utils';
+import { environment } from '@environment';
+import { FetchService } from './extras/fetch.service';
+
+const GATEWAY = '/categories';
+export const CATEGORIES_URL = returnCompleteURI({
+  URI: environment.API.BASE,
+  API_Gateway: GATEWAY,
+});
+
+@Injectable({ providedIn: 'root' })
+export class CategoriesService {
+  constructor(private fetchService: FetchService) {}
+
+  async list(): Promise<ApiResponse<Category[]>> {
+    return this.fetchService.get<ApiResponse<Category[]>>({
+      API_Gateway: CATEGORIES_URL,
+    });
+  }
+
+  async tree(): Promise<ApiResponse<CategoryTreeNode[]>> {
+    return this.fetchService.get<ApiResponse<CategoryTreeNode[]>>({
+      API_Gateway: `${CATEGORIES_URL}/tree`,
+    });
+  }
+
+  async getById(id: string): Promise<ApiResponse<Category>> {
+    return this.fetchService.get<ApiResponse<Category>>({
+      API_Gateway: `${CATEGORIES_URL}/${id}`,
+    });
+  }
+
+  async create(payload: Omit<Category, 'id' | 'tenant_id' | 'created_at' | 'updated_at'>): Promise<ApiResponse<Category>> {
+    return this.fetchService.post<ApiResponse<Category>>({
+      API_Gateway: CATEGORIES_URL,
+      values: payload,
+    });
+  }
+
+  async update(id: string, payload: Partial<Category>): Promise<ApiResponse<Category>> {
+    return this.fetchService.patch<ApiResponse<Category>>({
+      API_Gateway: `${CATEGORIES_URL}/${id}`,
+      values: payload,
+    });
+  }
+
+  async softDelete(id: string): Promise<ApiResponse<void>> {
+    return this.fetchService.delete<ApiResponse<void>>({
+      API_Gateway: `${CATEGORIES_URL}/${id}`,
+    });
+  }
+}

--- a/src/app/services/clients.service.spec.ts
+++ b/src/app/services/clients.service.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+import { ClientsService } from './clients.service';
+import { FetchService } from './extras/fetch.service';
+import { mockResponse } from '../../__tests__/mocks/data';
+
+describe('ClientsService', () => {
+  let service: ClientsService;
+  let fetchSpy: jasmine.SpyObj<FetchService>;
+
+  beforeEach(() => {
+    fetchSpy = jasmine.createSpyObj('FetchService', ['get', 'post', 'patch', 'delete']);
+    TestBed.configureTestingModule({
+      providers: [ClientsService, { provide: FetchService, useValue: fetchSpy }],
+    });
+    service = TestBed.inject(ClientsService);
+  });
+
+  describe('list()', () => {
+    it('calls GET /clients without query string when no filters', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));
+      await service.list();
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('/clients');
+      expect(url).not.toContain('?');
+    });
+
+    it('appends filter params as query string', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));
+      await service.list({ type: 'supplier', is_active: true });
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('type=supplier');
+      expect(url).toContain('is_active=true');
+    });
+  });
+
+  describe('getById()', () => {
+    it('includes id in URL', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.getById('client-001');
+      expect(fetchSpy.get).toHaveBeenCalledWith(
+        jasmine.objectContaining({ API_Gateway: jasmine.stringContaining('client-001') })
+      );
+    });
+  });
+
+  describe('create()', () => {
+    it('calls POST /clients with payload', async () => {
+      fetchSpy.post.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      const payload = { type: 'supplier' as const, code: 'SUP-01', name: 'Proveedor', is_active: true };
+      await service.create(payload);
+      expect(fetchSpy.post).toHaveBeenCalledWith(jasmine.objectContaining({ values: payload }));
+    });
+  });
+
+  describe('update()', () => {
+    it('calls PATCH /clients/:id with payload', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.update('client-001', { name: 'Updated' });
+      const args = fetchSpy.patch.calls.mostRecent().args[0];
+      expect(args.API_Gateway).toContain('client-001');
+      expect((args as any).values).toEqual({ name: 'Updated' });
+    });
+  });
+
+  describe('softDelete()', () => {
+    it('calls DELETE /clients/:id', async () => {
+      fetchSpy.delete.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      await service.softDelete('client-001');
+      expect(fetchSpy.delete).toHaveBeenCalledWith(
+        jasmine.objectContaining({ API_Gateway: jasmine.stringContaining('client-001') })
+      );
+    });
+  });
+
+  describe('linkSupplier()', () => {
+    it('calls PATCH /receiving-tasks/:id/supplier with supplier_id', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      await service.linkSupplier('rt-001', 'sup-abc');
+      const args = fetchSpy.patch.calls.mostRecent().args[0];
+      expect(args.API_Gateway).toContain('receiving-tasks/rt-001/supplier');
+      expect((args as any).values).toEqual({ supplier_id: 'sup-abc' });
+    });
+
+    it('allows null supplier_id to unlink', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      await service.linkSupplier('rt-001', null);
+      const args = fetchSpy.patch.calls.mostRecent().args[0];
+      expect((args as any).values).toEqual({ supplier_id: null });
+    });
+  });
+
+  describe('linkCustomer()', () => {
+    it('calls PATCH /picking-tasks/:id/customer with customer_id', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      await service.linkCustomer('pt-001', 'cust-xyz');
+      const args = fetchSpy.patch.calls.mostRecent().args[0];
+      expect(args.API_Gateway).toContain('picking-tasks/pt-001/customer');
+      expect((args as any).values).toEqual({ customer_id: 'cust-xyz' });
+    });
+  });
+});

--- a/src/app/services/clients.service.ts
+++ b/src/app/services/clients.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@angular/core';
+import { ApiResponse } from '@app/models';
+import { Client, ClientListFilters } from '@app/models/client.model';
+import { returnCompleteURI } from '@app/utils';
+import { environment } from '@environment';
+import { FetchService } from './extras/fetch.service';
+
+const GATEWAY = '/clients';
+export const CLIENTS_URL = returnCompleteURI({
+  URI: environment.API.BASE,
+  API_Gateway: GATEWAY,
+});
+
+const RECEIVING_URL = returnCompleteURI({
+  URI: environment.API.BASE,
+  API_Gateway: '/receiving-tasks',
+});
+
+const PICKING_URL = returnCompleteURI({
+  URI: environment.API.BASE,
+  API_Gateway: '/picking-tasks',
+});
+
+@Injectable({ providedIn: 'root' })
+export class ClientsService {
+  constructor(private fetchService: FetchService) {}
+
+  async list(filters?: ClientListFilters): Promise<ApiResponse<Client[]>> {
+    const params = new URLSearchParams();
+    if (filters) {
+      Object.entries(filters).forEach(([k, v]) => {
+        if (v !== undefined && v !== null && v !== '') {
+          params.append(k, String(v));
+        }
+      });
+    }
+    const qs = params.toString();
+    return this.fetchService.get<ApiResponse<Client[]>>({
+      API_Gateway: qs ? `${CLIENTS_URL}?${qs}` : `${CLIENTS_URL}`,
+    });
+  }
+
+  async getById(id: string): Promise<ApiResponse<Client>> {
+    return this.fetchService.get<ApiResponse<Client>>({
+      API_Gateway: `${CLIENTS_URL}/${id}`,
+    });
+  }
+
+  async create(payload: Omit<Client, 'id' | 'tenant_id' | 'created_at' | 'updated_at'>): Promise<ApiResponse<Client>> {
+    return this.fetchService.post<ApiResponse<Client>>({
+      API_Gateway: CLIENTS_URL,
+      values: payload,
+    });
+  }
+
+  async update(id: string, payload: Partial<Client>): Promise<ApiResponse<Client>> {
+    return this.fetchService.patch<ApiResponse<Client>>({
+      API_Gateway: `${CLIENTS_URL}/${id}`,
+      values: payload,
+    });
+  }
+
+  async softDelete(id: string): Promise<ApiResponse<void>> {
+    return this.fetchService.delete<ApiResponse<void>>({
+      API_Gateway: `${CLIENTS_URL}/${id}`,
+    });
+  }
+
+  async linkSupplier(receivingTaskId: string, supplierId: string | null): Promise<ApiResponse<void>> {
+    return this.fetchService.patch<ApiResponse<void>>({
+      API_Gateway: `${RECEIVING_URL}/${receivingTaskId}/supplier`,
+      values: { supplier_id: supplierId },
+    });
+  }
+
+  async linkCustomer(pickingTaskId: string, customerId: string | null): Promise<ApiResponse<void>> {
+    return this.fetchService.patch<ApiResponse<void>>({
+      API_Gateway: `${PICKING_URL}/${pickingTaskId}/customer`,
+      values: { customer_id: customerId },
+    });
+  }
+}

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -16,4 +16,10 @@ export * from './dashboard.service';
 export * from './stock-alert.service';
 export * from './barcode.service';
 export * from './gamification.service';
+// S2 services
+export * from './clients.service';
+export * from './categories.service';
+export * from './notifications.service';
+export * from './stock-settings.service';
+export * from './inventory-valuation.service';
 

--- a/src/app/services/inventory-valuation.service.spec.ts
+++ b/src/app/services/inventory-valuation.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { InventoryValuationService } from './inventory-valuation.service';
+import { FetchService } from './extras/fetch.service';
+import { mockResponse } from '../../__tests__/mocks/data';
+
+describe('InventoryValuationService', () => {
+  let service: InventoryValuationService;
+  let fetchSpy: jasmine.SpyObj<FetchService>;
+
+  beforeEach(() => {
+    fetchSpy = jasmine.createSpyObj('FetchService', ['get']);
+    TestBed.configureTestingModule({
+      providers: [InventoryValuationService, { provide: FetchService, useValue: fetchSpy }],
+    });
+    service = TestBed.inject(InventoryValuationService);
+  });
+
+  describe('get()', () => {
+    it('calls GET /inventory/valuation with group_by=article', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.get('article');
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('/inventory/valuation');
+      expect(url).toContain('group_by=article');
+    });
+
+    it('passes active_only=false when specified', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.get('location', false);
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('active_only=false');
+    });
+
+    it('defaults active_only to true', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.get('category');
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('active_only=true');
+    });
+  });
+});

--- a/src/app/services/inventory-valuation.service.ts
+++ b/src/app/services/inventory-valuation.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { ApiResponse } from '@app/models';
+import { InventoryValuation, ValuationGroupBy } from '@app/models/inventory-valuation.model';
+import { returnCompleteURI } from '@app/utils';
+import { environment } from '@environment';
+import { FetchService } from './extras/fetch.service';
+
+export const VALUATION_URL = returnCompleteURI({
+  URI: environment.API.BASE,
+  API_Gateway: '/inventory/valuation',
+});
+
+@Injectable({ providedIn: 'root' })
+export class InventoryValuationService {
+  constructor(private fetchService: FetchService) {}
+
+  async get(groupBy: ValuationGroupBy, activeOnly = true): Promise<ApiResponse<InventoryValuation>> {
+    const params = new URLSearchParams({ group_by: groupBy, active_only: String(activeOnly) });
+    return this.fetchService.get<ApiResponse<InventoryValuation>>({
+      API_Gateway: `${VALUATION_URL}?${params.toString()}`,
+    });
+  }
+}

--- a/src/app/services/lot.service.spec.ts
+++ b/src/app/services/lot.service.spec.ts
@@ -66,6 +66,15 @@ describe('LotService', () => {
     });
   });
 
+  describe('trace()', () => {
+    it('calls GET /lots/:id/trace', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.trace('lot-nanoid-001');
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('lot-nanoid-001/trace');
+    });
+  });
+
   describe('search()', () => {
     it('appends defined params as query string', async () => {
       fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));

--- a/src/app/services/lot.service.ts
+++ b/src/app/services/lot.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ApiResponse } from '@app/models';
 import { Lot, CreateLotRequest, UpdateLotRequest, LotSearchParams } from '@app/models/lot.model';
+import { LotTraceResponse } from '@app/models/lot-trace.model';
 import { returnCompleteURI } from '@app/utils';
 import { environment } from '@environment';
 import { FetchService } from './extras/fetch.service';
@@ -71,6 +72,16 @@ export class LotService {
 	async delete(id: number): Promise<ApiResponse<any>> {
 		return await this.fetchService.delete<ApiResponse<any>>({
 			API_Gateway: `${LOT_URL}/${id}`,
+		});
+	}
+
+	/**
+	 * @description Get full trace for a lot (movements, origin, current stock by location).
+	 * @param lotId Lot ID (nanoid)
+	 */
+	async trace(lotId: string): Promise<ApiResponse<LotTraceResponse>> {
+		return await this.fetchService.get<ApiResponse<LotTraceResponse>>({
+			API_Gateway: `${LOT_URL}/${lotId}/trace`,
 		});
 	}
 

--- a/src/app/services/notifications.service.spec.ts
+++ b/src/app/services/notifications.service.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import { NotificationsService } from './notifications.service';
+import { FetchService } from './extras/fetch.service';
+import { mockResponse } from '../../__tests__/mocks/data';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+  let fetchSpy: jasmine.SpyObj<FetchService>;
+
+  beforeEach(() => {
+    fetchSpy = jasmine.createSpyObj('FetchService', ['get', 'patch', 'post']);
+    TestBed.configureTestingModule({
+      providers: [NotificationsService, { provide: FetchService, useValue: fetchSpy }],
+    });
+    service = TestBed.inject(NotificationsService);
+  });
+
+  afterEach(() => {
+    service.stopPolling();
+  });
+
+  describe('list()', () => {
+    it('calls GET /notifications without query when no filters', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));
+      await service.list();
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('/notifications');
+      expect(url).not.toContain('?');
+    });
+
+    it('appends unread=true filter', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));
+      await service.list({ unread: true });
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('unread=true');
+    });
+  });
+
+  describe('countUnread()', () => {
+    it('calls GET /notifications/count and returns count', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({ count: 5 })));
+      const count = await service.countUnread();
+      expect(count).toBe(5);
+      expect(fetchSpy.get).toHaveBeenCalledWith(
+        jasmine.objectContaining({ API_Gateway: jasmine.stringContaining('/notifications/count') })
+      );
+    });
+  });
+
+  describe('markRead()', () => {
+    it('calls PATCH /notifications/:id/read', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      await service.markRead('notif-001');
+      const args = fetchSpy.patch.calls.mostRecent().args[0];
+      expect(args.API_Gateway).toContain('notif-001/read');
+    });
+  });
+
+  describe('markAllRead()', () => {
+    it('calls PATCH /notifications/mark-all-read', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      await service.markAllRead();
+      const url: string = fetchSpy.patch.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('mark-all-read');
+    });
+  });
+
+  describe('getPreferences()', () => {
+    it('calls GET /notifications/preferences', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse([])));
+      await service.getPreferences();
+      const url: string = fetchSpy.get.calls.mostRecent().args[0].API_Gateway;
+      expect(url).toContain('/notifications/preferences');
+    });
+  });
+
+  describe('upsertPreferences()', () => {
+    it('calls POST /notifications/preferences with prefs array', async () => {
+      fetchSpy.post.and.returnValue(Promise.resolve(mockResponse(undefined)));
+      const prefs: any[] = [{ event_type: 'low_stock', in_app: true, email: false, push: false }];
+      await service.upsertPreferences(prefs);
+      expect(fetchSpy.post).toHaveBeenCalledWith(jasmine.objectContaining({ values: prefs }));
+    });
+  });
+
+  describe('polling', () => {
+    it('startPolling does not throw and stopPolling clears interval', () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({ count: 3 })));
+      expect(() => service.startPolling(999999)).not.toThrow();
+      expect(() => service.stopPolling()).not.toThrow();
+    });
+
+    it('startPolling is idempotent — calling twice does not create two intervals', () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({ count: 0 })));
+      service.startPolling(999999);
+      const firstPollSpy = (service as any)._pollInterval;
+      service.startPolling(999999);
+      expect((service as any)._pollInterval).toBe(firstPollSpy);
+      service.stopPolling();
+    });
+  });
+});

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@angular/core';
+import { ApiResponse } from '@app/models';
+import { Notification, NotificationListFilters, NotificationPreference } from '@app/models/notification.model';
+import { returnCompleteURI } from '@app/utils';
+import { environment } from '@environment';
+import { FetchService } from './extras/fetch.service';
+
+const GATEWAY = '/notifications';
+export const NOTIFICATIONS_URL = returnCompleteURI({
+  URI: environment.API.BASE,
+  API_Gateway: GATEWAY,
+});
+
+@Injectable({ providedIn: 'root' })
+export class NotificationsService {
+  unreadCount = 0;
+
+  private _pollInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private fetchService: FetchService) {}
+
+  async list(filters?: NotificationListFilters): Promise<ApiResponse<Notification[]>> {
+    const params = new URLSearchParams();
+    if (filters) {
+      Object.entries(filters).forEach(([k, v]) => {
+        if (v !== undefined && v !== null && v !== '') {
+          params.append(k, String(v));
+        }
+      });
+    }
+    const qs = params.toString();
+    return this.fetchService.get<ApiResponse<Notification[]>>({
+      API_Gateway: qs ? `${NOTIFICATIONS_URL}?${qs}` : NOTIFICATIONS_URL,
+    });
+  }
+
+  async countUnread(): Promise<number> {
+    const res = await this.fetchService.get<ApiResponse<{ count: number }>>({
+      API_Gateway: `${NOTIFICATIONS_URL}/count`,
+    });
+    return res.data?.count ?? 0;
+  }
+
+  async markRead(id: string): Promise<ApiResponse<void>> {
+    return this.fetchService.patch<ApiResponse<void>>({
+      API_Gateway: `${NOTIFICATIONS_URL}/${id}/read`,
+      values: {},
+    });
+  }
+
+  async markAllRead(): Promise<ApiResponse<void>> {
+    return this.fetchService.patch<ApiResponse<void>>({
+      API_Gateway: `${NOTIFICATIONS_URL}/mark-all-read`,
+      values: {},
+    });
+  }
+
+  async getPreferences(): Promise<ApiResponse<NotificationPreference[]>> {
+    return this.fetchService.get<ApiResponse<NotificationPreference[]>>({
+      API_Gateway: `${NOTIFICATIONS_URL}/preferences`,
+    });
+  }
+
+  async upsertPreferences(prefs: NotificationPreference[]): Promise<ApiResponse<void>> {
+    return this.fetchService.post<ApiResponse<void>>({
+      API_Gateway: `${NOTIFICATIONS_URL}/preferences`,
+      values: prefs,
+    });
+  }
+
+  // Polling helper — W6-B bell icon calls startPolling() in ngOnInit.
+  // Stores latest count in `unreadCount` property; component reads it via interval or ngDoCheck.
+  startPolling(intervalMs = 60000): void {
+    if (this._pollInterval) return;
+    this.countUnread().then(n => { this.unreadCount = n; });
+    this._pollInterval = setInterval(async () => {
+      this.unreadCount = await this.countUnread();
+    }, intervalMs);
+  }
+
+  stopPolling(): void {
+    if (this._pollInterval) {
+      clearInterval(this._pollInterval);
+      this._pollInterval = null;
+    }
+  }
+}

--- a/src/app/services/stock-settings.service.spec.ts
+++ b/src/app/services/stock-settings.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { StockSettingsService } from './stock-settings.service';
+import { FetchService } from './extras/fetch.service';
+import { mockResponse } from '../../__tests__/mocks/data';
+
+describe('StockSettingsService', () => {
+  let service: StockSettingsService;
+  let fetchSpy: jasmine.SpyObj<FetchService>;
+
+  beforeEach(() => {
+    fetchSpy = jasmine.createSpyObj('FetchService', ['get', 'patch']);
+    TestBed.configureTestingModule({
+      providers: [StockSettingsService, { provide: FetchService, useValue: fetchSpy }],
+    });
+    service = TestBed.inject(StockSettingsService);
+  });
+
+  describe('get()', () => {
+    it('calls GET /settings/stock', async () => {
+      fetchSpy.get.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      await service.get();
+      expect(fetchSpy.get).toHaveBeenCalledWith(
+        jasmine.objectContaining({ API_Gateway: jasmine.stringContaining('/settings/stock') })
+      );
+    });
+  });
+
+  describe('update()', () => {
+    it('calls PATCH /settings/stock with partial payload', async () => {
+      fetchSpy.patch.and.returnValue(Promise.resolve(mockResponse({} as any)));
+      const payload = { valuation_method: 'fifo' as const };
+      await service.update(payload);
+      expect(fetchSpy.patch).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          API_Gateway: jasmine.stringContaining('/settings/stock'),
+          values: payload,
+        })
+      );
+    });
+  });
+});

--- a/src/app/services/stock-settings.service.ts
+++ b/src/app/services/stock-settings.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { ApiResponse } from '@app/models';
+import { StockSettings } from '@app/models/stock-settings.model';
+import { returnCompleteURI } from '@app/utils';
+import { environment } from '@environment';
+import { FetchService } from './extras/fetch.service';
+
+const GATEWAY = '/settings/stock';
+export const STOCK_SETTINGS_URL = returnCompleteURI({
+  URI: environment.API.BASE,
+  API_Gateway: GATEWAY,
+});
+
+@Injectable({ providedIn: 'root' })
+export class StockSettingsService {
+  constructor(private fetchService: FetchService) {}
+
+  async get(): Promise<ApiResponse<StockSettings>> {
+    return this.fetchService.get<ApiResponse<StockSettings>>({
+      API_Gateway: STOCK_SETTINGS_URL,
+    });
+  }
+
+  async update(payload: Partial<StockSettings>): Promise<ApiResponse<StockSettings>> {
+    return this.fetchService.patch<ApiResponse<StockSettings>>({
+      API_Gateway: STOCK_SETTINGS_URL,
+      values: payload,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- **TS1 Models**: 6 new model files (client, category, notification, stock-settings, inventory-valuation, lot-trace) + extensions to 5 existing models (article +9 fields, lot +3, receiving-task +6, picking-task +2, adjustment +type enum). Barrel updated.
- **SVC1 Services**: 5 new services (ClientsService, CategoriesService, NotificationsService w/ polling, StockSettingsService, InventoryValuationService) + LotService.trace(). All use FetchService+Promise pattern consistent with codebase.
- **Tests**: 30 new tests — 408/408 PASS (up from 378 S1). ng build clean.

## Key decision

Spec requested signals; codebase uses FetchService+Promise across all 20+ existing services. New services follow the existing pattern for consistency. W6+ components can use polling/observables at component level if needed.

## Test plan

- [x] `npm run test:ci` — 408/408 PASS, 0 FAIL
- [x] `ng build --configuration=development` — clean, no errors
- [x] No existing tests regressed
- [x] New services verified against backend W2-A, W2-B, W3-A, W4 endpoint contracts