### PR TITLE
ci: migrate deploy to VPS Manager webhook + env-aware registry

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,8 +6,9 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: eflowcr/estock-frontend
+  REGISTRY: registry.eflowsuite.com
+  IMAGE_PATH: dev/estock-frontend
+  VPSM_PROJECT_ID: 3z011zx2w122wz2w112ww
 
 jobs:
   type-check:
@@ -15,50 +16,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
-
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
-
       - name: Generate environment (CI fallback)
         run: node scripts/load-env.js
         env:
           API_BASE: http://localhost:8081/api
-
       - name: Build (type-check + compile)
         run: npx ng build --configuration development --no-progress
 
   build-and-push:
     needs: type-check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to eflowsuite registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=estock-frontend
-            org.opencontainers.image.vendor=eflowcr
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and Push
         uses: docker/build-push-action@v5
@@ -73,23 +57,31 @@ jobs:
             TESTING=true
             PRODUCTION=false
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.title=estock-frontend
+            org.opencontainers.image.vendor=eflowcr
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Notify VPS Manager — update all client stacks
+  notify-vps-manager:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger redeploy via VPS Manager webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.VPSM_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.VPSM_WEBHOOK_SECRET }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}
+          TAG: latest
+          PROJECT_ID: ${{ env.VPSM_PROJECT_ID }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${{ secrets.VPS_SECRET_TOKEN }}" \
+          RESPONSE=$(curl -sf -w "\nHTTP:%{http_code}" -X POST \
+            -H "Authorization: Bearer ${WEBHOOK_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"image_tag\":\"dev-${{ github.sha }}\",\"environment\":\"development\"}" \
-            "https://vps-manager-api.31.97.145.251.nip.io/api/v1/stacks/update" \
-            && echo "✅ Frontend dev deploy triggered" \
-            || echo "⚠️  No active client stacks (or update skipped)"
-
-      - name: Verify
-        run: |
-          echo "✅ ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev pushed"
-          echo "Branch: ${{ github.ref_name }} | SHA: ${{ github.sha }}"
+            -d "{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\",\"project_id\":\"${PROJECT_ID}\"}" \
+            "${WEBHOOK_URL}")
+          echo "${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "HTTP:200" || exit 1

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy Frontend (Main)
+name: Build & Deploy Frontend (QA)
 
 on:
   push:
@@ -6,10 +6,9 @@ on:
   workflow_dispatch:
 
 env:
-  GHCR_REGISTRY: ghcr.io
-  GHCR_IMAGE: eflowcr/estock-frontend
-  SELF_REGISTRY: 31.97.145.251:5000
-  SELF_IMAGE: prod/estock-frontend
+  REGISTRY: registry.eflowsuite.com
+  IMAGE_PATH: qa/estock-frontend
+  VPSM_PROJECT_ID: 3z011zx2w122wz2w112ww
 
 jobs:
   type-check:
@@ -33,55 +32,17 @@ jobs:
   build-and-push:
     needs: type-check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
 
-      # Trust the self-hosted registry's self-signed certificate
-      - name: Trust self-hosted registry certificate
-        run: |
-          sudo mkdir -p /etc/docker/certs.d/31.97.145.251:5000
-          echo | openssl s_client -connect 31.97.145.251:5000 -servername 31.97.145.251 2>/dev/null \
-            | openssl x509 \
-            | sudo tee /etc/docker/certs.d/31.97.145.251:5000/ca.crt
-          # Also write buildkitd config for buildx
-          cat > /tmp/buildkitd.toml << 'EOF'
-          [registry."31.97.145.251:5000"]
-            ca=["/etc/docker/certs.d/31.97.145.251:5000/ca.crt"]
-          EOF
-
       - uses: docker/setup-buildx-action@v3
-        with:
-          config: /tmp/buildkitd.toml
 
-      # Login to GHCR
-      - name: Login to GHCR
+      - name: Login to eflowsuite registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Login to self-hosted registry
-      - name: Login to self-hosted registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.SELF_REGISTRY }}
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE }}
-            ${{ env.SELF_REGISTRY }}/${{ env.SELF_IMAGE }}
-          labels: |
-            org.opencontainers.image.title=estock-frontend
-            org.opencontainers.image.vendor=eflowcr
 
       - name: Build and Push
         uses: docker/build-push-action@v5
@@ -93,35 +54,34 @@ jobs:
             API_BASE=/api
             ENVIRONMENT=production
             VERSION=${{ github.sha }}
-            TESTING=false
-            PRODUCTION=true
+            TESTING=true
+            PRODUCTION=false
           tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE }}:production
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE }}:production-${{ github.sha }}
-            ${{ env.SELF_REGISTRY }}/${{ env.SELF_IMAGE }}:latest
-            ${{ env.SELF_REGISTRY }}/${{ env.SELF_IMAGE }}:${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.title=estock-frontend
+            org.opencontainers.image.vendor=eflowcr
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Notify VPS Manager — update all client stacks
+  notify-vps-manager:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger redeploy via VPS Manager webhook
         env:
-          SHA: ${{ github.sha }}
-          VPS_SECRET_TOKEN: ${{ secrets.VPS_SECRET_TOKEN }}
+          WEBHOOK_URL: ${{ secrets.VPSM_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.VPSM_WEBHOOK_SECRET }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}
+          TAG: latest
+          PROJECT_ID: ${{ env.VPSM_PROJECT_ID }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${VPS_SECRET_TOKEN}" \
+          RESPONSE=$(curl -sf -w "\nHTTP:%{http_code}" -X POST \
+            -H "Authorization: Bearer ${WEBHOOK_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"image_tag\":\"production-${SHA}\",\"environment\":\"production\"}" \
-            "https://vps-manager-api.31.97.145.251.nip.io/api/v1/stacks/update" \
-            && echo "Production frontend deploy triggered" \
-            || echo "No active client stacks (or update skipped)"
-
-      - name: Verify
-        env:
-          SHA: ${{ github.sha }}
-        run: |
-          echo "GHCR: ghcr.io/eflowcr/estock-frontend:production pushed"
-          echo "GHCR: ghcr.io/eflowcr/estock-frontend:production-${SHA} pushed"
-          echo "Self: 31.97.145.251:5000/prod/estock-frontend:latest pushed"
-          echo "Self: 31.97.145.251:5000/prod/estock-frontend:${SHA} pushed"
+            -d "{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\",\"project_id\":\"${PROJECT_ID}\"}" \
+            "${WEBHOOK_URL}")
+          echo "${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "HTTP:200" || exit 1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,8 +10,9 @@ on:
         required: true
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: eflowcr/estock-frontend
+  REGISTRY: registry.eflowsuite.com
+  IMAGE_PATH: prod/estock-frontend
+  VPSM_PROJECT_ID: 3z011zx2w122wz2w112ww
 
 jobs:
   type-check:
@@ -19,30 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
-
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
-
       - name: Generate environment
         run: node scripts/load-env.js
         env:
           API_BASE: /api
-
       - name: Build check (production)
         run: npx ng build --configuration production --no-progress
 
   build-and-push:
     needs: type-check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
+    outputs:
+      version: ${{ steps.ver.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,28 +45,23 @@ jobs:
 
       - name: Resolve version tag
         id: ver
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Login to GHCR
+      - name: Login to eflowsuite registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=estock-frontend
-            org.opencontainers.image.vendor=eflowcr
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and Push
         uses: docker/build-push-action@v5
@@ -86,23 +76,31 @@ jobs:
             TESTING=false
             PRODUCTION=true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.tag }}
-          labels: ${{ steps.meta.outputs.labels }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:${{ steps.ver.outputs.tag }}
+          labels: |
+            org.opencontainers.image.title=estock-frontend
+            org.opencontainers.image.vendor=eflowcr
+            org.opencontainers.image.version=${{ steps.ver.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Notify VPS Manager — update all client stacks
+  notify-vps-manager:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger redeploy via VPS Manager webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.VPSM_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.VPSM_WEBHOOK_SECRET }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}
+          TAG: ${{ needs.build-and-push.outputs.version }}
+          PROJECT_ID: ${{ env.VPSM_PROJECT_ID }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${{ secrets.VPS_SECRET_TOKEN }}" \
+          RESPONSE=$(curl -sf -w "\nHTTP:%{http_code}" -X POST \
+            -H "Authorization: Bearer ${WEBHOOK_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"image_tag\":\"${{ steps.ver.outputs.tag }}\",\"environment\":\"production\"}" \
-            "https://vps-manager-api.31.97.145.251.nip.io/api/v1/stacks/update" \
-            && echo "✅ Production frontend deploy triggered: ${{ steps.ver.outputs.tag }}" \
-            || echo "⚠️  Deploy trigger failed or no active stacks"
-
-      - name: Verify
-        run: |
-          echo "✅ ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.tag }} pushed"
-          echo "✅ ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest updated"
+            -d "{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\",\"project_id\":\"${PROJECT_ID}\"}" \
+            "${WEBHOOK_URL}")
+          echo "${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "HTTP:200" || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,14 @@ RUN printf "API_BASE=%s\nVERSION=%s\nTESTING=%s\nPRODUCTION=%s\n" \
 
 RUN npm run build -- --configuration=$ENVIRONMENT --source-map=false
 
-FROM nginx:alpine
+# nginx-unprivileged runs as uid 101 and binds on :8080 (required by VPS Manager SecurityContext)
+FROM nginxinc/nginx-unprivileged:alpine
 WORKDIR /usr/share/nginx/html
+USER root
 RUN rm -rf ./*
-COPY --from=build /usr/local/app/dist/eSTOCK_frontend/browser .
-COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build --chown=nginx:nginx /usr/local/app/dist/eSTOCK_frontend/browser .
+COPY --chown=nginx:nginx ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
+USER nginx
 
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen 8080;
   server_name localhost;
   location / {
     # This would be the directory where your Web app's static files are stored at


### PR DESCRIPTION
## Summary

Migrates the 3 deploy workflows (dev/main/prod) + Dockerfile from the legacy SSH-token model to the new VPS Manager webhook pattern.

**What changes:**

- **deploy-dev.yml** (dev branch) → pushes to `registry.eflowsuite.com/dev/estock-frontend:latest` → webhook triggers redeploy of development clients
- **deploy-main.yml** (main branch) → pushes to `qa/estock-frontend:latest` → redeploy of qa clients
- **deploy-prod.yml** (tag `v*` / workflow_dispatch) → pushes to `prod/estock-frontend:<tag>` → redeploy of production clients
- **Dockerfile** → switches base from `nginx:alpine` to `nginxinc/nginx-unprivileged:alpine`, binds on port **8080** (not 80). Required by VPS Manager post-S13 SecurityContext.
- **nginx/nginx.conf** → `listen 8080`.

**Service/ingress impact:** when provisioning the eSTOCK frontend client on VPS Manager, the Service should target port **8080**.

## Secrets

**Already set:** `REGISTRY_HOST`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, `VPSM_WEBHOOK_URL`, `VPSM_WEBHOOK_SECRET`.

**Safe to delete:** `VPS_SECRET_TOKEN`, `VPS_SSH_KEY`.

## Test plan

- [ ] Merge + push dev → image lands + webhook 200
- [ ] Local smoke: docker run -p 8080:8080 boots nginx as uid 101
- [ ] First client provision via VPS Manager uses service port 8080
- [ ] Tag v0.1.0 tests prod path