### PR TITLE
fix(s3.6.1): ingestExternalToken consume role+permissions from verify response (B22 frontend complement)

### DIFF
--- a/src/app/components/signup/signup-verify/signup-verify.component.spec.ts
+++ b/src/app/components/signup/signup-verify/signup-verify.component.spec.ts
@@ -83,7 +83,14 @@ describe('SignupVerifyComponent', () => {
 
   it('B2 S3.6: ingests JWT into AuthService and navigates to /onboarding on verify success', fakeAsync(async () => {
     const { fixture, component, signupSpy, router } = await createFixture('valid-token');
-    const verifyData = { token: MOCK_JWT, tenant_id: 't1', email: 'a@b.com', name: 'Admin' };
+    const verifyData = {
+      token: MOCK_JWT,
+      tenant_id: 't1',
+      email: 'a@b.com',
+      name: 'Admin',
+      role: 'Admin',
+      permissions: { all: true },
+    };
     signupSpy.verifySignup.and.returnValue(Promise.resolve(mockResponse(verifyData)));
 
     fixture.detectChanges();
@@ -91,7 +98,17 @@ describe('SignupVerifyComponent', () => {
 
     // AuthService.ingestExternalToken() must be called BEFORE the navigate
     // so AuthGuard sees an authenticated state on /onboarding.
-    expect(authSpy.ingestExternalToken).toHaveBeenCalledWith(MOCK_JWT);
+    // S3.6.1: caller must forward role+permissions so persisted AuthData
+    // matches the /auth/login shape (otherwise isAdmin/hasPermission fail).
+    expect(authSpy.ingestExternalToken).toHaveBeenCalledWith(
+      MOCK_JWT,
+      jasmine.objectContaining({
+        role: 'Admin',
+        permissions: { all: true },
+        email: 'a@b.com',
+        name: 'Admin',
+      }),
+    );
     expect(router.navigate).toHaveBeenCalledWith(['/onboarding']);
   }));
 

--- a/src/app/components/signup/signup-verify/signup-verify.component.ts
+++ b/src/app/components/signup/signup-verify/signup-verify.component.ts
@@ -62,12 +62,25 @@ export class SignupVerifyComponent implements OnInit {
         success?: boolean;
         message?: string;
         token?: string;
+        role?: string;
+        permissions?: any;
+        email?: string;
+        name?: string;
       };
       const success = response?.result?.success ?? flat?.success === true;
       const issuedToken = response?.data?.token ?? flat?.token;
 
       if (success && issuedToken) {
-        this.authService.ingestExternalToken(issuedToken);
+        // S3.6.1: forward role+permissions from verify response so AuthService
+        // hydrates the same fields /auth/login produces. Without this the
+        // sidebar permission checks fall back to false and the menu collapses.
+        const data = response?.data as any;
+        this.authService.ingestExternalToken(issuedToken, {
+          role: data?.role ?? flat?.role,
+          permissions: data?.permissions ?? flat?.permissions,
+          email: data?.email ?? flat?.email,
+          name: data?.name ?? flat?.name,
+        });
         this.state = 'success';
         // Brief success flash, then navigate to onboarding (first-time user).
         setTimeout(() => {

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -179,6 +179,47 @@ describe('AuthService', () => {
     });
   });
 
+  // ─── ingestExternalToken ──────────────────────────────────────────────────
+
+  describe('ingestExternalToken()', () => {
+    it('persists token-only AuthData when no enrichment provided (back-compat)', () => {
+      service.ingestExternalToken(MOCK_JWT);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(stored.token).toBe(MOCK_JWT);
+      expect(stored.role).toBeUndefined();
+      expect(stored.permissions).toBeUndefined();
+      expect(service.isAuthenticated()).toBeTrue();
+    });
+
+    it('S3.6.1: persists role+permissions when enrichment provided', () => {
+      service.ingestExternalToken(MOCK_JWT, {
+        role: 'Admin',
+        permissions: { all: true },
+        email: 'a@b.com',
+        name: 'Alice',
+      });
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(stored.token).toBe(MOCK_JWT);
+      expect(stored.role).toBe('Admin');
+      expect(stored.permissions).toEqual({ all: true });
+      expect(stored.email).toBe('a@b.com');
+      expect(stored.name).toBe('Alice');
+      expect(service.isAuthenticated()).toBeTrue();
+    });
+
+    it('does nothing when token is empty', () => {
+      service.ingestExternalToken('');
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(service.isAuthenticated()).toBeFalse();
+    });
+
+    it('clears state when token is malformed', () => {
+      service.ingestExternalToken('not.a.jwt', { role: 'Admin' });
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(service.isAuthenticated()).toBeFalse();
+    });
+  });
+
   // ─── changePassword ───────────────────────────────────────────────────────
 
   describe('changePassword()', () => {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { ApiResponse, AuthData, AuthState, LoginRequest, RegisterRequest, User } from '@app/models';
+import { ApiResponse, AuthData, AuthState, LoginRequest, Permission, RegisterRequest, User } from '@app/models';
 import { getApiErrorMessage, returnCompleteURI } from '@app/utils';
 import { environment } from '@environment';
 import { BehaviorSubject } from 'rxjs';
@@ -304,12 +304,34 @@ export class AuthService {
 	 * the signup verify flow so the user lands authenticated on /onboarding
 	 * instead of being redirected to /login by AuthGuard.
 	 *
-	 * B2 fix S3.6.
+	 * B2 fix S3.6 (initial). S3.6.1: accept optional `enrichment` carrying
+	 * role+permissions+identity so the persisted AuthData matches the shape
+	 * /auth/login produces. Without this, isAdmin()/hasPermission() report
+	 * false after signup verify and the side menu collapses.
+	 *
+	 * Backend complement: S3.5.6 (B22) — verify response now includes
+	 * role+permissions+email+name in `data`.
 	 * @memberof AuthService
 	 */
-	ingestExternalToken(token: string): void {
+	ingestExternalToken(
+		token: string,
+		enrichment?: {
+			role?: string;
+			permissions?: Permission;
+			email?: string;
+			name?: string;
+			last_name?: string;
+		},
+	): void {
 		if (!token) return;
-		const authData: AuthData = { token } as AuthData;
+		const authData: AuthData = {
+			token,
+			role: enrichment?.role,
+			permissions: enrichment?.permissions,
+			email: enrichment?.email,
+			name: enrichment?.name ?? '',
+			last_name: enrichment?.last_name ?? '',
+		} as AuthData;
 		localStorage.setItem(this.AUTH_STORAGE_KEY, JSON.stringify(authData));
 		try {
 			const user = this.decodeTokenPayload(token);

--- a/src/app/services/signup.service.ts
+++ b/src/app/services/signup.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ApiResponse } from '@app/models';
+import { ApiResponse, Permission } from '@app/models';
 import { returnCompleteURI } from '@app/utils';
 import { environment } from '@environment';
 import { FetchService } from './extras/fetch.service';
@@ -17,6 +17,11 @@ export interface SignupVerifyResponse {
   tenant_id: string;
   email: string;
   name: string;
+  // S3.6.1: backend (S3.5.6) now enriches verify response with role+permissions
+  // so the frontend can hydrate AuthService without a second /auth/me round-trip.
+  role?: string;
+  permissions?: Permission;
+  last_name?: string;
 }
 
 const GATEWAY = '/signup';


### PR DESCRIPTION
## Summary

Frontend complement to backend **S3.5.6 / B22** (deployed v0.2.7) which enriched `/signup/verify` response with `role` + `permissions`.

- `AuthService.ingestExternalToken()` was dropping the enrichment fields (only persisting `{token}` in localStorage), causing `isAdmin()` / `hasPermission()` to return `false` after signup verify and the sidebar to collapse for newly-onboarded admins.
- Extends the ingest signature to accept optional `enrichment` and persists the same shape that `/auth/login` produces.
- Caller in `SignupVerifyComponent` now forwards `response.data.{role,permissions,email,name}`.

## Changes

- `src/app/services/auth.service.ts` — extend `ingestExternalToken(token, enrichment?)`.
- `src/app/services/signup.service.ts` — extend `SignupVerifyResponse` with optional `role` / `permissions` / `last_name`.
- `src/app/components/signup/signup-verify/signup-verify.component.ts` — forward enrichment from `response.data` to ingest.
- `src/app/services/auth.service.spec.ts` — 4 new tests (back-compat, enrichment, empty token, malformed token).
- `src/app/components/signup/signup-verify/signup-verify.component.spec.ts` — update B2 spec to assert enrichment forwarding.

## Test plan

- [x] `ng build --configuration production` clean (only pre-existing CommonJS warnings).
- [x] `ng test --watch=false --browsers=ChromeHeadless` → **944/944 SUCCESS**, 0 NEW failures.
- [x] grep merge markers → 0 hits.
- [x] `git status` → only the 5 expected files modified.
- [ ] QA: signup new tenant -> verify email -> onboarding -> sidebar shows full Admin menu (no collapse).
- [ ] Smoke: existing login path unchanged (no regression on `/auth/login`).

## Notes

- DO NOT MERGE until QA validates the sidebar behavior on the verify -> onboarding flow.
- Companion to backend PR (S3.5.6 / B22) already in v0.2.7.