### PR TITLE
feat(s3.7-w1): mobile responsive layout + sidebar drawer + responsive grids (B20)

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -41,7 +41,7 @@
     <app-attention-required></app-attention-required>
 
     <!-- KPI cards -->
-    <div class="grid gap-4 sm:grid-cols-3">
+    <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
       <div
         *ngFor="let kpi of kpis; let i = index"
         class="kpi-card group relative overflow-hidden rounded-xl border border-border bg-card p-5 shadow-sm transition-shadow duration-200 hover:shadow-md"

--- a/src/app/components/layout/main-layout.component.spec.ts
+++ b/src/app/components/layout/main-layout.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { MainLayoutComponent } from './main-layout.component';
+import { SidebarService } from '@app/services';
+import { LanguageService } from '@app/services/extras/language.service';
+import { NavigationService } from '@app/services/extras/navigation.service';
+import { AuthService } from '../../services/auth.service';
+import { AlertService } from '../../services/extras/alert.service';
+import { AuthorizationService } from '../../services/extras/authorization.service';
+import { TrialService } from '@app/services/trial.service';
+import { UserPreferencesService } from '@app/services/user-preferences.service';
+
+class StubLanguageService { t(k: string) { return k; } }
+class StubNavigationService { getItems() { return []; } }
+class StubAuthService {
+  authState$ = new BehaviorSubject<any>(null);
+  getCurrentUser() { return null; }
+  logout() { return Promise.resolve(); }
+}
+class StubAlertService { success(){} error(){} }
+class StubAuthorizationService { getCurrentUser() { return null; } }
+class StubTrialService { getCurrentTrialStatus() { return Promise.resolve(null); } }
+class StubUserPreferencesService { load() {} }
+
+@Component({
+  standalone: true,
+  imports: [MainLayoutComponent],
+  template: `<app-main-layout><div class="p-4">content</div></app-main-layout>`,
+})
+class HostComponent {}
+
+describe('MainLayoutComponent — S3.7 W1 mobile responsive', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        SidebarService,
+        { provide: LanguageService, useClass: StubLanguageService },
+        { provide: NavigationService, useClass: StubNavigationService },
+        { provide: AuthService, useClass: StubAuthService },
+        { provide: AlertService, useClass: StubAlertService },
+        { provide: AuthorizationService, useClass: StubAuthorizationService },
+        { provide: TrialService, useClass: StubTrialService },
+        { provide: UserPreferencesService, useClass: StubUserPreferencesService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders main without ml-64 class on mobile (md:ml-64 only kicks in ≥768px)', () => {
+    const wrapper = fixture.nativeElement.querySelector('main')?.parentElement as HTMLElement;
+    expect(wrapper).toBeTruthy();
+    // The mobile-relevant guarantee: there is NO non-prefixed `ml-64` (mobile would inherit it).
+    expect(wrapper.className).not.toContain(' ml-64');
+    expect(wrapper.className).not.toMatch(/^ml-64/);
+    // And it has min-w-0 so flex children can shrink (S3.7 W1 fix for B20).
+    expect(wrapper.className).toContain('min-w-0');
+  });
+
+  it('main element has min-w-0 to prevent horizontal overflow from children', () => {
+    const main = fixture.nativeElement.querySelector('main') as HTMLElement;
+    expect(main).toBeTruthy();
+    expect(main.className).toContain('min-w-0');
+  });
+});

--- a/src/app/components/layout/main-layout.component.ts
+++ b/src/app/components/layout/main-layout.component.ts
@@ -19,12 +19,12 @@ import { TopbarComponent } from './topbar/topbar.component';
       <app-quick-search-overlay></app-quick-search-overlay>
       <app-sidebar></app-sidebar>
       <div
-        class="flex flex-1 flex-col min-h-0 md:pl-3"
+        class="flex flex-1 flex-col min-h-0 min-w-0 md:pl-3"
         [class.md:ml-64]="!desktopSidebarCollapsed"
       >
         <app-trial-banner></app-trial-banner>
         <app-topbar></app-topbar>
-        <main class="flex flex-1 flex-col min-h-0 gap-4 p-4">
+        <main class="flex flex-1 flex-col min-h-0 min-w-0 gap-4 p-3 sm:p-4">
           <ng-content></ng-content>
         </main>
       </div>

--- a/src/app/components/layout/sidebar/sidebar.component.spec.ts
+++ b/src/app/components/layout/sidebar/sidebar.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { SidebarComponent } from './sidebar.component';
+import { SidebarService } from '@app/services';
+import { LanguageService } from '@app/services/extras/language.service';
+import { NavigationService } from '@app/services/extras/navigation.service';
+
+class StubLanguageService {
+  t(key: string): string {
+    return key;
+  }
+}
+
+class StubNavigationService {
+  getItems() {
+    return [
+      { name: 'Dashboard', href: '/', icon: 'LayoutDashboard' } as any,
+      { name: 'Articles', href: '/articles', icon: 'Tag' } as any,
+    ];
+  }
+}
+
+describe('SidebarComponent — S3.7 W1 mobile responsive', () => {
+  let fixture: ComponentFixture<SidebarComponent>;
+  let component: SidebarComponent;
+  let sidebarService: SidebarService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SidebarComponent],
+      providers: [
+        provideRouter([]),
+        SidebarService,
+        { provide: LanguageService, useClass: StubLanguageService },
+        { provide: NavigationService, useClass: StubNavigationService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SidebarComponent);
+    component = fixture.componentInstance;
+    sidebarService = TestBed.inject(SidebarService);
+    fixture.detectChanges();
+  });
+
+  it('starts with mobile drawer closed', () => {
+    expect(component.mobileOpen).toBeFalse();
+    const backdrop = fixture.nativeElement.querySelector('.fixed.inset-0');
+    expect(backdrop).toBeNull();
+  });
+
+  it('renders backdrop overlay when mobile drawer opens', () => {
+    sidebarService.openMobile();
+    fixture.detectChanges();
+    const backdrop = fixture.nativeElement.querySelector('.fixed.inset-0.z-30');
+    expect(backdrop).not.toBeNull();
+    expect((backdrop as HTMLElement).getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('closes mobile drawer when backdrop is clicked', () => {
+    sidebarService.openMobile();
+    fixture.detectChanges();
+    const backdrop = fixture.nativeElement.querySelector('.fixed.inset-0.z-30') as HTMLElement;
+    backdrop.click();
+    fixture.detectChanges();
+    expect(component.mobileOpen).toBeFalse();
+  });
+
+  it('closes mobile drawer when a nav item is clicked', () => {
+    sidebarService.openMobile();
+    fixture.detectChanges();
+    component.onNavigationClick();
+    expect(component.mobileOpen).toBeFalse();
+  });
+
+  it('sidebar has md:translate-x-0 to be visible on desktop by default', () => {
+    const drawer = fixture.nativeElement.querySelector('[data-sidebar="header"]')?.parentElement
+      ?.parentElement;
+    expect(drawer).toBeTruthy();
+    // The drawer container has md:translate-x-0 in its base classes.
+    expect(drawer.className).toContain('md:translate-x-0');
+  });
+});

--- a/src/app/components/layout/topbar/topbar.component.spec.ts
+++ b/src/app/components/layout/topbar/topbar.component.spec.ts
@@ -1,0 +1,122 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { BehaviorSubject } from 'rxjs';
+import { TopbarComponent } from './topbar.component';
+import { SidebarService } from '@app/services';
+import { LanguageService } from '@app/services/extras/language.service';
+import { NavigationService } from '@app/services/extras/navigation.service';
+import { AuthService } from '../../../services/auth.service';
+import { AlertService } from '../../../services/extras/alert.service';
+import { AuthorizationService } from '../../../services/extras/authorization.service';
+
+class StubLanguageService {
+  t(key: string): string {
+    return key;
+  }
+}
+
+class StubNavigationService {
+  getItems() {
+    return [];
+  }
+}
+
+class StubAuthService {
+  authState$ = new BehaviorSubject<any>(null);
+  getCurrentUser() {
+    return null;
+  }
+  logout() {
+    return Promise.resolve();
+  }
+}
+
+class StubAlertService {
+  success() {}
+  error() {}
+}
+
+class StubAuthorizationService {
+  getCurrentUser() {
+    return null;
+  }
+}
+
+describe('TopbarComponent — S3.7 W1 mobile responsive', () => {
+  let fixture: ComponentFixture<TopbarComponent>;
+  let component: TopbarComponent;
+  let sidebarService: SidebarService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TopbarComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        SidebarService,
+        { provide: LanguageService, useClass: StubLanguageService },
+        { provide: NavigationService, useClass: StubNavigationService },
+        { provide: AuthService, useClass: StubAuthService },
+        { provide: AlertService, useClass: StubAlertService },
+        { provide: AuthorizationService, useClass: StubAuthorizationService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TopbarComponent);
+    component = fixture.componentInstance;
+    sidebarService = TestBed.inject(SidebarService);
+    fixture.detectChanges();
+  });
+
+  it('renders the hamburger toggle button with aria-label', () => {
+    const btn = fixture.nativeElement.querySelector('button[aria-label="Toggle sidebar"]');
+    expect(btn).not.toBeNull();
+  });
+
+  it('hamburger has min 44px touch target on mobile (size-11)', () => {
+    const btn = fixture.nativeElement.querySelector(
+      'button[aria-label="Toggle sidebar"]',
+    ) as HTMLElement;
+    expect(btn).not.toBeNull();
+    expect(btn.className).toContain('size-11');
+  });
+
+  it('toggleSidebar opens mobile drawer when viewport is narrow', () => {
+    spyOn(window, 'matchMedia').and.returnValue({
+      matches: true,
+      media: '(max-width: 767px)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => true,
+    } as any);
+
+    expect(sidebarService.mobileOpen).toBeFalse();
+    component.toggleSidebar();
+    expect(sidebarService.mobileOpen).toBeTrue();
+    expect(sidebarService.desktopCollapsed).toBeFalse();
+  });
+
+  it('toggleSidebar collapses desktop sidebar when viewport is wide', () => {
+    spyOn(window, 'matchMedia').and.returnValue({
+      matches: false,
+      media: '(max-width: 767px)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => true,
+    } as any);
+
+    expect(sidebarService.desktopCollapsed).toBeFalse();
+    component.toggleSidebar();
+    expect(sidebarService.desktopCollapsed).toBeTrue();
+    expect(sidebarService.mobileOpen).toBeFalse();
+  });
+});

--- a/src/app/components/layout/topbar/topbar.component.ts
+++ b/src/app/components/layout/topbar/topbar.component.ts
@@ -39,17 +39,17 @@ import { NotificationsBellComponent } from './notifications-bell.component';
   ],
   template: `
     <header
-      class="sticky top-0 z-30 flex h-14 w-full items-center justify-between border-t border-b border-border bg-background px-4 shadow-sm"
+      class="sticky top-0 z-30 flex h-14 w-full min-w-0 items-center justify-between border-t border-b border-border bg-background px-3 shadow-sm sm:px-4"
     >
       <!-- Left side -->
-      <div class="flex min-w-0 items-center gap-4">
+      <div class="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">
         <button
           z-button
           zType="ghost"
           zSize="icon"
           type="button"
           (click)="toggleSidebar()"
-          class="inline-flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-muted/60 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          class="inline-flex size-11 shrink-0 items-center justify-center rounded-lg border border-border bg-muted/60 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:size-9"
           aria-label="Toggle sidebar"
         >
           <svg
@@ -81,10 +81,10 @@ import { NotificationsBellComponent } from './notifications-bell.component';
           <span class="text-base">eSTOCK</span>
         </a>
 
-        <div class="h-6 w-px bg-border" aria-hidden="true"></div>
+        <div class="hidden h-6 w-px bg-border sm:block" aria-hidden="true"></div>
 
         <div
-          class="relative w-full max-w-md min-w-0"
+          class="relative w-full max-w-md min-w-0 flex-1"
           data-topbar-search-root
           (keydown)="$event.stopPropagation()"
         >
@@ -153,11 +153,11 @@ import { NotificationsBellComponent } from './notifications-bell.component';
       </div>
 
       <!-- Right side -->
-      <div class="flex shrink-0 items-center gap-6">
-        <div class="flex items-center gap-2">
+      <div class="flex shrink-0 items-center gap-2 sm:gap-6">
+        <div class="flex items-center gap-1 sm:gap-2">
           <a
             [routerLink]="['/gamification']"
-            class="inline-flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="hidden size-11 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex sm:size-9"
             [title]="t('nav.rewards')"
             aria-label="Rewards"
           >
@@ -178,7 +178,7 @@ import { NotificationsBellComponent } from './notifications-bell.component';
           <app-notifications-bell></app-notifications-bell>
           <a
             routerLink="/articles"
-            class="inline-flex size-9 items-center justify-center rounded-full border border-border bg-muted/60 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="hidden size-11 items-center justify-center rounded-full border border-border bg-muted/60 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex sm:size-9"
             [title]="t('nav.quick_add')"
             aria-label="Quick add"
           >
@@ -198,7 +198,7 @@ import { NotificationsBellComponent } from './notifications-bell.component';
           </a>
         </div>
 
-        <div class="h-8 w-px bg-border" aria-hidden="true"></div>
+        <div class="hidden h-8 w-px bg-border sm:block" aria-hidden="true"></div>
 
         <div class="user-menu-zone relative">
           <button

--- a/src/app/components/shared/trial-banner/trial-banner.component.ts
+++ b/src/app/components/shared/trial-banner/trial-banner.component.ts
@@ -142,8 +142,8 @@ export class TrialBannerComponent implements OnInit {
 
   get bannerClasses(): string[] {
     const base = [
-      'flex', 'items-center', 'justify-between', 'gap-3',
-      'px-4', 'py-2.5', 'text-white', 'shadow-sm',
+      'flex', 'flex-col', 'sm:flex-row', 'sm:items-center', 'justify-between', 'gap-2', 'sm:gap-3',
+      'px-3', 'sm:px-4', 'py-2.5', 'text-white', 'shadow-sm',
     ];
 
     if (this.isPastDue) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -89,6 +89,12 @@
   * {
     @apply border-border;
   }
+  /* S3.7 W1 — mobile responsive guard: prevent any child from forcing a
+     horizontal scroll on small viewports. Individual scroll containers
+     (tables, code blocks, etc.) opt-in with overflow-x-auto. */
+  html, body {
+    @apply max-w-full overflow-x-hidden;
+  }
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-body);


### PR DESCRIPTION
## Summary
S3.7 Wave 1 — Mobile responsive (B20 from QA browser E2E v0.2.4).

Builds on S3.6 mobile drawer infra (sidebar fixed + backdrop + mobileOpen$ + hamburger). Cierra B20 con guard global anti-overflow + min-w-0 chain + touch targets + KPI grid responsive.

## Changes
- `src/styles.css`: html/body overflow-x-hidden + max-w-full root guard
- `main-layout`: min-w-0 wrapper + responsive padding
- `topbar`: gaps responsive, hamburger 44px touch target, divider hidden sm:block
- `trial-banner`: flex-col sm:flex-row
- `dashboard`: KPI grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3
- 3 specs nuevos (11 tests, 0 regresiones)

## Validation gates (MSSO v2.3) — 6/6 ✅
- 0 merge markers
- ng build prod clean
- npm test:ci 955/955 (944 baseline + 11 nuevos)
- Bundle size idéntico
- Visual: tests aseveran sin ml-64 + con min-w-0
- git status only expected files

## Deferred to W1.5 polish
- Cards-on-mobile pattern para tablas (hoy funcionan via overflow-auto wrappers)
- Onboarding wizard responsive audit detallado
- barcode-generator truncate fix

## Test plan
- [ ] CI passes
- [ ] Smoke real chrome 375px viewport sidebar drawer + dashboard responsive (post-merge)