### PR TITLE
fix(s3.7-w2): dashboard accuracy (B6 NaN + B7 2800% + B8 currency mix + B10 duplicates)

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -54,14 +54,24 @@
           <div class="min-w-0 flex-1">
             <p class="text-sm font-medium text-muted-foreground">{{ t(kpi.title) }}</p>
             <p class="mt-1.5 text-2xl font-bold tracking-tight">{{ kpi.value }}</p>
-            <p class="mt-1.5 flex items-center gap-1 text-xs"
-              [class.text-red-500]="kpi.changePercent < 0"
-              [class.text-emerald-600]="kpi.changePercent > 0"
-              [class.text-muted-foreground]="kpi.changePercent === 0">
-              <span>{{ kpi.changePercent > 0 ? '↑' : kpi.changePercent < 0 ? '↓' : '→' }}</span>
-              <span>{{ kpi.changePercent }}%</span>
-              <span class="text-muted-foreground">{{ t(kpi.changeLabel || 'dashboard.vs_last_month') }}</span>
+            <!-- B7 fix: changePercent is null when there's no prev-period data
+                 (e.g. tenant created today). Show "—" + "no previous data" text
+                 instead of an absurd "↑ 2800%". -->
+            <p *ngIf="kpi.changePercent === null; else changePctTpl"
+              class="mt-1.5 flex items-center gap-1 text-xs text-muted-foreground">
+              <span>—</span>
+              <span>{{ t('dashboard.no_previous_data') }}</span>
             </p>
+            <ng-template #changePctTpl>
+              <p class="mt-1.5 flex items-center gap-1 text-xs"
+                [class.text-red-500]="(kpi.changePercent || 0) < 0"
+                [class.text-emerald-600]="(kpi.changePercent || 0) > 0"
+                [class.text-muted-foreground]="(kpi.changePercent || 0) === 0">
+                <span>{{ (kpi.changePercent || 0) > 0 ? '↑' : (kpi.changePercent || 0) < 0 ? '↓' : '→' }}</span>
+                <span>{{ kpi.changePercent }}%</span>
+                <span class="text-muted-foreground">{{ t(kpi.changeLabel || 'dashboard.vs_last_month') }}</span>
+              </p>
+            </ng-template>
           </div>
           <!-- Icon -->
           <div class="ml-3 shrink-0 rounded-lg p-2.5" [style.background]="kpiIconBg(kpi.icon)">

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -184,7 +184,8 @@ export class DashboardComponent implements OnInit {
         Section: 'KPI',
         Metric: this.t(k.title),
         Value: k.value,
-        'Change %': `${k.changePercent}%`,
+        // B7: changePercent may be null (no prev-period data) — export "—" not "null%".
+        'Change %': k.changePercent === null ? '—' : `${k.changePercent}%`,
       })),
       ...this.tableRows.map(r => ({
         Section: 'Top Articles',

--- a/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.spec.ts
+++ b/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.spec.ts
@@ -82,4 +82,12 @@ describe('InventoryValuationWidgetComponent', () => {
     const formatted = component.formatCurrency(1000);
     expect(formatted).toContain('1');
   });
+
+  // B6: prevents "₡NaN" rendering when value is NaN/Infinity/null/undefined.
+  it('formatCurrency guards against NaN/Infinity/null (B6)', () => {
+    expect(component.formatCurrency(NaN)).not.toContain('NaN');
+    expect(component.formatCurrency(Infinity)).not.toContain('NaN');
+    expect(component.formatCurrency(null)).not.toContain('NaN');
+    expect(component.formatCurrency(undefined)).not.toContain('NaN');
+  });
 });

--- a/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.ts
+++ b/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.ts
@@ -75,12 +75,19 @@ export class InventoryValuationWidgetComponent implements OnInit {
     return {};
   }
 
-  formatCurrency(value: number): string {
+  /**
+   * B6 fix: guard against NaN/null/undefined/Infinity before format.
+   * Returns localized "₡0" instead of "₡NaN" when value is not a finite number.
+   * B8 fix: tenant locale defaults to es-CR (CRC) — single source of truth for currency
+   * across the dashboard. KPI cards must use this same formatter (no $ mixing).
+   */
+  formatCurrency(value: number | null | undefined): string {
+    const n = typeof value === 'number' && Number.isFinite(value) ? value : 0;
     return new Intl.NumberFormat('es-CR', {
       style: 'currency',
       currency: 'CRC',
       maximumFractionDigits: 0,
-    }).format(value);
+    }).format(n);
   }
 
   t(key: string): string {

--- a/src/app/models/dashboard.model.ts
+++ b/src/app/models/dashboard.model.ts
@@ -18,11 +18,13 @@ export interface StockAlert {
   alertLevel: AlertLevel;
 }
 
-/** KPI card with optional trend for dashboard overview */
+/** KPI card with optional trend for dashboard overview.
+ *  changePercent is `null` when no previous-period data exists
+ *  (e.g. tenant created today). UI must render '—' / "no prev data". */
 export interface DashboardKpi {
   title: string;
   value: string;
-  changePercent: number;
+  changePercent: number | null;
   changeLabel?: string;
   icon: string;
 }

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -67,7 +67,9 @@ describe('DashboardService', () => {
       const kpis = service.buildKpis(MOCK_STATS);
       expect(kpis.length).toBe(3);
       expect(kpis[0].value).toBe('120');
-      expect(kpis[1].value).toContain('50,000');
+      // B8: inventory_value uses CRC formatter (es-CR), not "$".
+      expect(kpis[1].value).toContain('50');
+      expect(kpis[1].value).not.toContain('$');
       expect(kpis[2].value).toBe('3');
     });
 
@@ -80,6 +82,30 @@ describe('DashboardService', () => {
     it('uses tasksChangePercent for low_stock_count', () => {
       const kpis = service.buildKpis(MOCK_STATS);
       expect(kpis[2].changePercent).toBe(10);
+    });
+
+    // B7 — sentinel: when prev was 0 the backend returns Infinity / absurd %.
+    it("shows '—' for KPI when prev=0 (changePercent is null)", () => {
+      const kpisInf = service.buildKpis({ ...MOCK_STATS, movChangePercent: Infinity } as any);
+      expect(kpisInf[0].changePercent).toBeNull();
+      expect(kpisInf[1].changePercent).toBeNull();
+
+      const kpisHuge = service.buildKpis({ ...MOCK_STATS, movChangePercent: 2800 } as any);
+      expect(kpisHuge[0].changePercent).toBeNull();
+
+      const kpisNaN = service.buildKpis({ ...MOCK_STATS, tasksChangePercent: NaN } as any);
+      expect(kpisNaN[2].changePercent).toBeNull();
+
+      const kpisNull = service.buildKpis({ ...MOCK_STATS, movChangePercent: null } as any);
+      expect(kpisNull[0].changePercent).toBeNull();
+    });
+
+    // B8 — Inventory Value uses tenant locale (es-CR / CRC).
+    it('Inventory Value uses currency from tenant locale', () => {
+      const kpis = service.buildKpis({ ...MOCK_STATS, inventoryValue: 70127 } as any);
+      // CRC symbol "₡" or "CRC" prefix per Intl runtime; never plain "$".
+      expect(kpis[1].value).not.toContain('$');
+      expect(kpis[1].value).toMatch(/CRC|₡/);
     });
   });
 
@@ -149,6 +175,70 @@ describe('DashboardService', () => {
       expect(result.length).toBe(1);
       expect(result[0].period).toBe('Jan');
       expect(result[0].segments.length).toBe(3);
+    });
+  });
+
+  // ─── getInventorySummary ──────────────────────────────────────────────────
+
+  describe('getInventorySummary()', () => {
+    // B10 fix
+    it('Top Articles deduplicates by article_id', async () => {
+      fetchSpy.get.and.returnValue(
+        Promise.resolve(
+          mockResponse({
+            topArticles: [
+              { id: 'a1', name: 'Diclofenaco 75mg/3mL Inj', type: 'Inj', ratePercent: 80, amount: 1305 },
+              { id: 'a1', name: 'Diclofenaco 75mg/3mL Inj', type: 'Inj', ratePercent: 80, amount: 1305 }, // dup
+              { id: 'a2', name: 'Ketorolaco 30mg/1mL Inj', type: 'Inj', ratePercent: 70, amount: 1260 },
+              { id: 'a2', name: 'Ketorolaco 30mg/1mL Inj', type: 'Inj', ratePercent: 70, amount: 1260 }, // dup
+            ],
+            locationDistribution: [],
+          })
+        )
+      );
+
+      const { topArticles } = await service.getInventorySummary();
+      expect(topArticles.length).toBe(2);
+      expect(topArticles.map((r) => r.id).sort()).toEqual(['a1', 'a2']);
+    });
+
+    // B6 fix
+    it('guards NaN amounts (does not render "₡NaN")', async () => {
+      fetchSpy.get.and.returnValue(
+        Promise.resolve(
+          mockResponse({
+            topArticles: [
+              { id: 'x', name: 'Clindamicina', type: 'Cap', ratePercent: NaN, amount: NaN },
+            ],
+            locationDistribution: [
+              { label: 'A', value: NaN, amount: NaN, color: '#000' },
+            ],
+          })
+        )
+      );
+
+      const { topArticles, locationDistribution } = await service.getInventorySummary();
+      expect(topArticles[0].amount).not.toContain('NaN');
+      expect(topArticles[0].ratePercent).toBe(0);
+      expect(locationDistribution[0].amount).not.toContain('NaN');
+      expect(locationDistribution[0].value).toBe(0);
+    });
+
+    // B8 fix
+    it('Top Articles amounts use CRC currency (no "$")', async () => {
+      fetchSpy.get.and.returnValue(
+        Promise.resolve(
+          mockResponse({
+            topArticles: [{ id: 'x', name: 'X', type: 'T', ratePercent: 10, amount: 70127 }],
+            locationDistribution: [{ label: 'A', value: 100, amount: 1000, color: '#000' }],
+          })
+        )
+      );
+
+      const { topArticles, locationDistribution } = await service.getInventorySummary();
+      expect(topArticles[0].amount).not.toContain('$');
+      expect(topArticles[0].amount).toMatch(/CRC|₡/);
+      expect(locationDistribution[0].amount).not.toContain('$');
     });
   });
 

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -29,38 +29,63 @@ export class DashboardService {
     });
   }
 
-  /** KPI cards with trend (tasksChangePercent and movChangePercent from real DB comparisons) */
+  /** KPI cards with trend (tasksChangePercent and movChangePercent from real DB comparisons).
+   *
+   *  B7 fix: when backend prev-period was 0, the % becomes Infinity / NaN / absurd
+   *  (e.g. "2800%"). Sanitize to `null` so UI renders "—" / "Sin datos previos".
+   *  Heuristic: any non-finite OR |%| > 1000 is treated as "no previous data".
+   *
+   *  B8 fix: inventory_value KPI now formatted in CRC (es-CR) — matches the
+   *  Inventory Valuation widget. No more "$70,127" vs "₡0" contradiction.
+   */
   buildKpis(stats: DashboardStats | null): DashboardKpi[] {
+    const fmtCRC = (v: number) =>
+      new Intl.NumberFormat('es-CR', {
+        style: 'currency',
+        currency: 'CRC',
+        maximumFractionDigits: 0,
+      }).format(Number.isFinite(v) ? v : 0);
+
     if (!stats) {
       return [
-        { title: 'total_skus', value: '—', changePercent: 0, changeLabel: 'dashboard.vs_last_month', icon: 'package' },
-        { title: 'inventory_value', value: '—', changePercent: 0, changeLabel: 'dashboard.vs_last_month', icon: 'trend' },
-        { title: 'low_stock_count', value: '—', changePercent: 0, changeLabel: 'dashboard.alerts_trend', icon: 'alert' },
+        { title: 'total_skus', value: '—', changePercent: null, changeLabel: 'dashboard.vs_last_month', icon: 'package' },
+        { title: 'inventory_value', value: '—', changePercent: null, changeLabel: 'dashboard.vs_last_month', icon: 'trend' },
+        { title: 'low_stock_count', value: '—', changePercent: null, changeLabel: 'dashboard.alerts_trend', icon: 'alert' },
       ];
     }
     return [
       {
         title: 'total_skus',
-        value: stats.totalSkus.toLocaleString(),
-        changePercent: stats.movChangePercent ?? 0,
+        value: (stats.totalSkus ?? 0).toLocaleString(),
+        changePercent: this.sanitizeChangePercent(stats.movChangePercent),
         changeLabel: 'dashboard.vs_last_month',
         icon: 'package',
       },
       {
         title: 'inventory_value',
-        value: `$${stats.inventoryValue.toLocaleString()}`,
-        changePercent: stats.movChangePercent ?? 0,
+        value: fmtCRC(stats.inventoryValue ?? 0),
+        changePercent: this.sanitizeChangePercent(stats.movChangePercent),
         changeLabel: 'dashboard.vs_last_month',
         icon: 'trend',
       },
       {
         title: 'low_stock_count',
-        value: stats.lowStockCount.toLocaleString(),
-        changePercent: stats.tasksChangePercent ?? 0,
+        value: (stats.lowStockCount ?? 0).toLocaleString(),
+        changePercent: this.sanitizeChangePercent(stats.tasksChangePercent),
         changeLabel: 'dashboard.alerts_trend',
         icon: 'alert',
       },
     ];
+  }
+
+  /** Returns null when the change percent is meaningless (no prev-period data). */
+  private sanitizeChangePercent(raw: number | null | undefined): number | null {
+    if (raw === null || raw === undefined) return null;
+    if (!Number.isFinite(raw)) return null;
+    // Backend prev=0 produces absurd values (e.g. 2800%). Treat anything beyond
+    // ±1000% as "no meaningful prior baseline".
+    if (Math.abs(raw) > 1000) return null;
+    return raw;
   }
 
   /** Stacked bar: movements by period — from /api/dashboard/movements-monthly?period= */
@@ -102,18 +127,42 @@ export class DashboardService {
       return { topArticles: [], locationDistribution: [] };
     }
 
-    const topArticles: DashboardTableRow[] = response.data.topArticles.map((a) => ({
+    // B6 fix: guard NaN/Infinity amounts before formatting (was rendering "₡NaN").
+    // B8 fix: switched from "$" to es-CR / CRC — single currency source of truth.
+    const fmtCRC = (v: number) => {
+      const n = Number.isFinite(v) ? v : 0;
+      return new Intl.NumberFormat('es-CR', {
+        style: 'currency',
+        currency: 'CRC',
+        maximumFractionDigits: 0,
+      }).format(n);
+    };
+
+    // B10 fix: dedup top articles by id (backend JOIN was producing duplicates,
+    // e.g. "Diclofenaco" appeared twice). Keep the highest-amount row per id.
+    const dedupedTop = new Map<string, { id: string; name: string; type: string; ratePercent: number; amount: number }>();
+    for (const a of response.data.topArticles ?? []) {
+      // Fallback key for legacy rows missing id — use composite name+type so we
+      // still collapse obvious dupes and never crash on undefined Map keys.
+      const key = a.id || `${a.name}::${a.type}`;
+      const existing = dedupedTop.get(key);
+      if (!existing || (a.amount ?? 0) > (existing.amount ?? 0)) {
+        dedupedTop.set(key, a);
+      }
+    }
+
+    const topArticles: DashboardTableRow[] = Array.from(dedupedTop.values()).map((a) => ({
       id: a.id,
       name: a.name,
       type: a.type,
-      ratePercent: Math.round(a.ratePercent),
-      amount: `$${a.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+      ratePercent: Number.isFinite(a.ratePercent) ? Math.round(a.ratePercent) : 0,
+      amount: fmtCRC(a.amount),
     }));
 
-    const locationDistribution: DonutSlice[] = response.data.locationDistribution.map((l) => ({
+    const locationDistribution: DonutSlice[] = (response.data.locationDistribution ?? []).map((l) => ({
       label: l.label,
-      value: l.value,
-      amount: `$${l.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+      value: Number.isFinite(l.value) ? l.value : 0,
+      amount: fmtCRC(l.amount),
       color: l.color,
     }));
 

--- a/src/app/translations/en.ts
+++ b/src/app/translations/en.ts
@@ -190,6 +190,7 @@ export const enTranslations = {
   manage_all_alerts: 'Manage alerts',
   'dashboard.vs_last_month': 'vs last month',
   'dashboard.alerts_trend': 'alerts trend',
+  'dashboard.no_previous_data': 'no previous data',
   'dashboard.movements_overview': 'Movements Overview',
   'dashboard.tasks_this_week': 'Tasks This Week',
   'dashboard.inventory_distribution': 'Inventory Distribution',

--- a/src/app/translations/es.ts
+++ b/src/app/translations/es.ts
@@ -218,6 +218,7 @@ export const esTranslations = {
   manage_all_alerts: 'Gestionar alertas',
   'dashboard.vs_last_month': 'vs mes anterior',
   'dashboard.alerts_trend': 'tendencia alertas',
+  'dashboard.no_previous_data': 'sin datos previos',
   'dashboard.movements_overview': 'Resumen de movimientos',
   'dashboard.tasks_this_week': 'Tareas esta semana',
   'dashboard.inventory_distribution': 'Distribución de inventario',


### PR DESCRIPTION
## Summary

Sprint S3.7 W2 — fixes the four dashboard-accuracy QA findings (B6/B7/B8/B10) from `2026-04-27-qa-browser-e2e-v0.2.4.md`.

- **B6** — Top items rendering `₡NaN`: guard `NaN`/`Infinity`/`null`/`undefined` in `formatCurrency` (widget) and in `DashboardService.getInventorySummary` before formatting amounts and rates.
- **B7** — KPIs showing absurd `↑ 2800% vs last month` for fresh tenants: backend returns `Infinity` when prev-period is 0. New `sanitizeChangePercent` collapses any non-finite or `|%|>1000` to `null`. UI then renders `— sin datos previos` (i18n key `dashboard.no_previous_data` added to `en`/`es`).
- **B8** — Currency contradiction (`₡0` vs `$70,127`): the inventory_value KPI, top articles and location distribution now share a single `Intl.NumberFormat('es-CR', { style: 'currency', currency: 'CRC' })` formatter alongside the valuation widget. No more `$` mixing on the dashboard.
- **B10** — Top Articles duplicates (`Diclofenaco`, `Ketorolaco` appearing twice): `getInventorySummary` deduplicates by `article_id` (falling back to `name::type`) and keeps the highest-amount row per id.

## Test plan

- [x] `ng build --configuration production` — clean (no errors)
- [x] `ng test --watch=false --browsers=ChromeHeadless` — 961/961 SUCCESS
- [x] New spec `shows '—' for KPI when prev=0` (Infinity / 2800 / NaN / null all → `null`)
- [x] New spec `Top Articles deduplicates by article_id`
- [x] New spec `Inventory Value uses currency from tenant locale` (asserts no `$`, matches `CRC|₡`)
- [x] New spec `formatCurrency guards against NaN/Infinity/null` in widget
- [x] New spec `guards NaN amounts (does not render "₡NaN")` for getInventorySummary
- [ ] Manual smoke (deferred to director): /dashboard with a fresh tenant — KPI cards show `— sin datos previos`, all amounts in ₡, no NaN, no duplicate rows.

## i18n

- `en.ts`: `dashboard.no_previous_data: 'no previous data'`
- `es.ts`: `dashboard.no_previous_data: 'sin datos previos'`

## Out of scope

- Backend root cause for the absurd `movChangePercent` (sentinel from prev=0) — frontend defends defensively now; backend cleanup tracked separately.
- B9 (article URLs by name vs UUID), B11 (i18n mix), B12 (sidebar lowercase) — not in W2 scope.