### PR TITLE
feat(s3.7-w4): architecture cleanups (B9 URLs UUID + B17 API adapter + B18 billing route)

### DIFF
--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,28 @@
+import { Routes } from '@angular/router';
+import { routes } from './app.routes';
+
+// B18 (S3.7-W4): /billing previously hit the wildcard route and silently
+// landed on /dashboard. The fix aliases it to /settings/billing so external
+// links (Stripe redirects, marketing emails, docs) resolve to the real
+// billing settings page.
+describe('App routes — B18 billing redirect', () => {
+  function findRoute(routeList: Routes, path: string) {
+    return routeList.find((r) => r.path === path);
+  }
+
+  it('exposes a top-level /billing route', () => {
+    expect(findRoute(routes, 'billing')).toBeDefined();
+  });
+
+  it('/billing redirects to /settings/billing', () => {
+    const route = findRoute(routes, 'billing');
+    expect(route?.redirectTo).toBe('/settings/billing');
+    expect(route?.pathMatch).toBe('full');
+  });
+
+  it('keeps the original /settings/billing route intact', () => {
+    const route = findRoute(routes, 'settings/billing');
+    expect(route).toBeDefined();
+    expect(route?.loadComponent).toBeDefined();
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -177,6 +177,15 @@ export const routes: Routes = [
     canActivate: [AuthGuard, PermissionGuard],
     data: { permissions: ['billing:read'] },
   },
+  // B18 (S3.7-W4): /billing previously fell through the wildcard route and
+  // redirected silently to the dashboard. Alias it to the real settings page
+  // so direct links from emails / docs / Stripe redirects always resolve to
+  // the billing surface.
+  {
+    path: 'billing',
+    redirectTo: '/settings/billing',
+    pathMatch: 'full',
+  },
   // S3-W4B: Sales Orders
   {
     path: 'sales-orders',

--- a/src/app/components/articles/article-detail/article-detail.component.spec.ts
+++ b/src/app/components/articles/article-detail/article-detail.component.spec.ts
@@ -29,8 +29,8 @@ const MOCK_ARTICLE: Article = {
 const okResponse = (data: any) => Promise.resolve({ result: { success: true, endpoint_code: '' }, data });
 const notFoundError = () => Promise.reject({ status: 404 });
 
-const mockArticleServiceOk = { getBySku: () => okResponse(MOCK_ARTICLE) };
-const mockArticleServiceNotFound = { getBySku: () => notFoundError() };
+const mockArticleServiceOk = { getBySku: () => okResponse(MOCK_ARTICLE), getById: () => okResponse(MOCK_ARTICLE) };
+const mockArticleServiceNotFound = { getBySku: () => notFoundError(), getById: () => notFoundError() };
 const mockAlertService = { success: jasmine.createSpy('success'), error: jasmine.createSpy('error') };
 const mockAuthAdmin = { isAdmin: () => true, isAuthenticated: () => true, hasPermission: () => true, getCurrentUser: () => ({ name: 'Test', last_name: 'User', role: 'Admin', email: 'test@test.com' }) };
 const mockLanguageService = { t: (key: string) => key };
@@ -164,13 +164,51 @@ describe('ArticleDetailComponent — 404 state', () => {
     }).compileComponents();
   });
 
-  it('sets notFound=true on 404', fakeAsync(() => {
+  it('sets notFound=true on 404 from both SKU and ID lookups', fakeAsync(() => {
     const fixture = TestBed.createComponent(ArticleDetailComponent);
     const comp = fixture.componentInstance;
     comp.ngOnInit();
     tick();
+    tick(); // second tick: let the B9 ID fallback also resolve before asserting
     expect(comp.notFound).toBe(true);
     expect(comp.article).toBeNull();
+  }));
+});
+
+// B9 (S3.7-W4): when SKU lookup 404s (e.g. when navigated by UUID from the
+// dashboard valuation widget), fall back to ID lookup before declaring the
+// article missing. This lets stable identifiers work transparently while the
+// route param is still nominally `:sku`.
+describe('ArticleDetailComponent — B9 ID fallback when SKU lookup 404s', () => {
+  const ART_BY_ID: Article = { ...MOCK_ARTICLE, id: 'art-uuid-001', sku: 'PROD-001' };
+
+  beforeEach(async () => {
+    const mockServiceWithFallback = {
+      getBySku: jasmine.createSpy('getBySku').and.returnValue(notFoundError()),
+      getById: jasmine.createSpy('getById').and.returnValue(okResponse(ART_BY_ID)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, RouterModule.forRoot([]), HttpClientTestingModule, ArticleDetailComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: ArticleService, useValue: mockServiceWithFallback },
+        { provide: AlertService, useValue: mockAlertService },
+        { provide: AuthorizationService, useValue: mockAuthAdmin },
+        { provide: LanguageService, useValue: mockLanguageService },
+        { provide: ActivatedRoute, useValue: makeRoute('art-uuid-001') },
+      ],
+    }).compileComponents();
+  });
+
+  it('falls back to getById when getBySku returns 404 and resolves the article', fakeAsync(() => {
+    const fixture = TestBed.createComponent(ArticleDetailComponent);
+    const comp = fixture.componentInstance;
+    comp.ngOnInit();
+    tick();
+    tick();
+    expect(comp.article?.id).toBe('art-uuid-001');
+    expect(comp.notFound).toBe(false);
   }));
 });
 

--- a/src/app/components/articles/article-detail/article-detail.component.ts
+++ b/src/app/components/articles/article-detail/article-detail.component.ts
@@ -74,17 +74,29 @@ export class ArticleDetailComponent implements OnInit {
     if (sku) this.loadArticle(sku);
   }
 
-  async loadArticle(sku: string): Promise<void> {
+  async loadArticle(skuOrId: string): Promise<void> {
     this.isLoading = true;
     this.notFound = false;
     try {
-      const res = await this.articleService.getBySku(sku);
+      const res = await this.articleService.getBySku(skuOrId);
       this.article = res.data ?? null;
       if (!this.article) this.notFound = true;
     } catch (error: any) {
       const status = Number(error?.status);
+      // B9 (S3.7-W4): the route param is `:sku` historically, but other parts
+      // of the app (e.g. dashboard valuation widget) route via the article's
+      // stable UUID. When SKU lookup 404s, retry as ID before giving up so
+      // both URL shapes work transparently.
       if (status === 404) {
-        this.notFound = true;
+        try {
+          const fallback = await this.articleService.getById(skuOrId as any);
+          this.article = fallback?.data ?? null;
+          if (!this.article) {
+            this.notFound = true;
+          }
+        } catch (idError: any) {
+          this.notFound = true;
+        }
       } else {
         this.alertService.error(this.t('article_detail.error_loading'));
       }

--- a/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.spec.ts
+++ b/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.spec.ts
@@ -90,4 +90,26 @@ describe('InventoryValuationWidgetComponent', () => {
     expect(component.formatCurrency(null)).not.toContain('NaN');
     expect(component.formatCurrency(undefined)).not.toContain('NaN');
   });
+
+  // B9 (S3.7-W4): article links must use the stable identifier (item.id),
+  // not the human-readable label, to avoid name-encoded URLs like
+  // /articles/Clindamicina%20300mg%20Caps%2016s.
+  describe('B9 — renders article links with stable id, not name', () => {
+    it('linkFor returns ["/articles", item.id] when grouping by article', () => {
+      component.groupBy = 'article';
+      const link = component.linkFor({ id: 'art-uuid-001', label: 'Clindamicina 300mg Caps 16s' });
+      expect(link).toEqual(['/articles', 'art-uuid-001']);
+      expect(link[1]).not.toContain(' ');
+    });
+
+    it('linkFor returns inventory route for location grouping', () => {
+      component.groupBy = 'location';
+      expect(component.linkFor({ id: 'loc-1', label: 'Almacen A' })).toEqual(['/inventory']);
+    });
+
+    it('linkFor returns generic articles route for category grouping', () => {
+      component.groupBy = 'category';
+      expect(component.linkFor({ id: 'cat-1', label: 'Antibioticos' })).toEqual(['/articles']);
+    });
+  });
 });

--- a/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.ts
+++ b/src/app/components/dashboard/widgets/inventory-valuation-widget/inventory-valuation-widget.component.ts
@@ -64,7 +64,12 @@ export class InventoryValuationWidgetComponent implements OnInit {
   }
 
   linkFor(item: { id: string; label: string }): string[] {
-    if (this.groupBy === 'article') return ['/articles', item.label];
+    // B9 (S3.7-W4): use stable identifier (item.id) instead of human label.
+    // The backend returns id as the article's UUID/SKU; using label embeds the
+    // article name in the URL which is fragile against renames and ugly when
+    // URL-encoded. The article-detail route falls back to UUID lookup when
+    // SKU lookup misses, so either identifier shape works.
+    if (this.groupBy === 'article') return ['/articles', item.id];
     if (this.groupBy === 'location') return ['/inventory'];
     return ['/articles'];
   }

--- a/src/app/utils/api-response.spec.ts
+++ b/src/app/utils/api-response.spec.ts
@@ -1,0 +1,106 @@
+import {
+  unwrapApiResponseList,
+  unwrapApiResponseItem,
+  isApiResponseListNonEmpty,
+} from './api-response';
+
+// B17 (S3.7-W4): adapter for inconsistent backend envelope shapes.
+describe('unwrapApiResponseList — normalizes various envelope shapes', () => {
+  // Shape #1 — articles: { data: T[] }
+  it('unwraps ApiResponse<T[]> (articles shape) to T[]', () => {
+    const resp = {
+      envelope: {} as any,
+      result: { success: true, message: '', endpoint_code: '' },
+      data: [{ id: '1' }, { id: '2' }],
+    };
+    expect(unwrapApiResponseList<{ id: string }>(resp)).toEqual([{ id: '1' }, { id: '2' }]);
+  });
+
+  // Shape #2 — sales-orders/delivery-notes/backorders: { data: { items: T[] } }
+  it('unwraps ApiResponse<{ items: T[] }> (sales-orders shape) to T[]', () => {
+    const resp = {
+      result: { success: true, message: '', endpoint_code: '' },
+      data: { items: [{ id: 'so-1' }], total: 1 },
+    };
+    expect(unwrapApiResponseList<{ id: string }>(resp as any)).toEqual([{ id: 'so-1' }]);
+  });
+
+  it('unwraps ApiResponse<{ data: T[] }> nested envelope', () => {
+    const resp = { data: { data: [{ id: 'x' }] } };
+    expect(unwrapApiResponseList(resp as any)).toEqual([{ id: 'x' }]);
+  });
+
+  it('unwraps ApiResponse<{ results: T[] }> paged envelope', () => {
+    const resp = { data: { results: [{ id: 'p' }], total: 1 } };
+    expect(unwrapApiResponseList(resp as any)).toEqual([{ id: 'p' }]);
+  });
+
+  // Shape #3 — stock-alerts: { data: null }
+  it('returns [] for ApiResponse<null> (stock-alerts empty shape)', () => {
+    const resp = { result: { success: true, message: '', endpoint_code: '' }, data: null };
+    expect(unwrapApiResponseList(resp as any)).toEqual([]);
+  });
+
+  // Shape #4 — lots: bare array, no envelope at all
+  it('passes through a bare T[] (lots shape)', () => {
+    const resp = [{ id: 'lot-1' }, { id: 'lot-2' }];
+    expect(unwrapApiResponseList(resp as any)).toEqual([{ id: 'lot-1' }, { id: 'lot-2' }]);
+  });
+
+  // Shape #5 — defensive
+  it('returns [] for null', () => {
+    expect(unwrapApiResponseList(null)).toEqual([]);
+  });
+
+  it('returns [] for undefined', () => {
+    expect(unwrapApiResponseList(undefined)).toEqual([]);
+  });
+
+  it('returns [] when data is an unrecognized object shape', () => {
+    const resp = { data: { foo: 'bar' } };
+    expect(unwrapApiResponseList(resp as any)).toEqual([]);
+  });
+});
+
+describe('unwrapApiResponseItem — single object payloads', () => {
+  it('returns data when ApiResponse<T> wraps an object', () => {
+    const resp = { data: { id: 'so-1', total: 100 } };
+    expect(unwrapApiResponseItem(resp as any)).toEqual({ id: 'so-1', total: 100 });
+  });
+
+  it('returns null when data is null', () => {
+    expect(unwrapApiResponseItem({ data: null } as any)).toBeNull();
+  });
+
+  it('returns null for null/undefined response', () => {
+    expect(unwrapApiResponseItem(null)).toBeNull();
+    expect(unwrapApiResponseItem(undefined)).toBeNull();
+  });
+
+  it('returns first element of array shape for resilience', () => {
+    expect(unwrapApiResponseItem({ data: [{ id: 'first' }, { id: 'second' }] } as any)).toEqual({ id: 'first' });
+  });
+
+  it('returns null for empty array', () => {
+    expect(unwrapApiResponseItem({ data: [] } as any)).toBeNull();
+  });
+});
+
+describe('isApiResponseListNonEmpty', () => {
+  it('returns true when list shape contains items', () => {
+    expect(isApiResponseListNonEmpty({ data: [{ id: '1' }] } as any)).toBeTrue();
+  });
+
+  it('returns false for empty array shape', () => {
+    expect(isApiResponseListNonEmpty({ data: [] } as any)).toBeFalse();
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isApiResponseListNonEmpty(null)).toBeFalse();
+    expect(isApiResponseListNonEmpty(undefined)).toBeFalse();
+  });
+
+  it('returns false for nested empty items envelope', () => {
+    expect(isApiResponseListNonEmpty({ data: { items: [] } } as any)).toBeFalse();
+  });
+});

--- a/src/app/utils/api-response.ts
+++ b/src/app/utils/api-response.ts
@@ -1,0 +1,91 @@
+import { ApiResponse } from '@app/models';
+
+/**
+ * B17 (S3.7-W4): Adapter to normalize varying API envelope shapes returned by
+ * the backend. Different services return inconsistent payloads:
+ *   - /api/articles/        → { data: T[] }       (array under data)
+ *   - /api/sales-orders/    → { data: { items: T[], ... } } (object wrapper)
+ *   - /api/delivery-notes/  → { data: { items: T[] } }
+ *   - /api/backorders/      → { data: { items: T[] } }
+ *   - /api/lots/            → T[]                 (no envelope at all)
+ *   - /api/stock-alerts/    → { data: null }      (null when empty)
+ *
+ * `unwrapApiResponseList<T>(resp)` flattens any of these into `T[]`.
+ * `unwrapApiResponseItem<T>(resp)` returns the single object payload.
+ *
+ * Frontend-only normalization — backend cleanup tracked separately.
+ */
+
+type AnyEnvelope<T> =
+  | ApiResponse<T>
+  | ApiResponse<T[]>
+  | ApiResponse<{ items?: T[]; data?: T[]; results?: T[] }>
+  | { data?: T | T[] | null }
+  | T[]
+  | null
+  | undefined;
+
+/**
+ * Unwrap a list payload from any of the inconsistent envelope shapes used by
+ * the eSTOCK backend. Always returns an array; falls back to `[]` when the
+ * response is null, undefined, or shaped unexpectedly.
+ *
+ * Recognised shapes:
+ *   1. `ApiResponse<T[]>`               → resp.data
+ *   2. `ApiResponse<{ items: T[] }>`    → resp.data.items (or .data / .results)
+ *   3. `ApiResponse<null>`              → []
+ *   4. raw array `T[]`                  → resp
+ *   5. anything else                    → []
+ */
+export function unwrapApiResponseList<T>(resp: AnyEnvelope<T>): T[] {
+  if (resp == null) return [];
+
+  // Shape #4: bare array (no envelope)
+  if (Array.isArray(resp)) return resp as T[];
+
+  // Anything from here is treated as having an envelope. Pull out `data`.
+  const data = (resp as { data?: unknown }).data;
+
+  // Shape #3: data is null/undefined
+  if (data == null) return [];
+
+  // Shape #1: data is already an array
+  if (Array.isArray(data)) return data as T[];
+
+  // Shape #2: data is an object wrapper — look for common nested array keys
+  if (typeof data === 'object') {
+    const candidate = data as Record<string, unknown>;
+    if (Array.isArray(candidate['items'])) return candidate['items'] as T[];
+    if (Array.isArray(candidate['data'])) return candidate['data'] as T[];
+    if (Array.isArray(candidate['results'])) return candidate['results'] as T[];
+    if (Array.isArray(candidate['list'])) return candidate['list'] as T[];
+  }
+
+  return [];
+}
+
+/**
+ * Unwrap a single-item payload. Returns null when the response is missing
+ * or wraps a null payload.
+ */
+export function unwrapApiResponseItem<T>(resp: AnyEnvelope<T> | { data?: T }): T | null {
+  if (resp == null) return null;
+  if (Array.isArray(resp)) return (resp[0] as T) ?? null;
+
+  const data = (resp as { data?: unknown }).data;
+  if (data == null) return null;
+
+  // If the backend wrapped a single item inside { data: { item: T } } we leave
+  // that to the caller — we only flatten when explicitly an array shape.
+  if (Array.isArray(data)) return (data[0] as T) ?? null;
+
+  return data as T;
+}
+
+/**
+ * Convenience: returns `true` only when the envelope reports success AND
+ * carries a non-null payload. Useful for guarding UI rendering.
+ */
+export function isApiResponseListNonEmpty(resp: AnyEnvelope<unknown>): boolean {
+  return unwrapApiResponseList(resp).length > 0;
+}

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -91,3 +91,4 @@ export function isApiResponseSuccessful(response: any): boolean {
 export * from './get-token';
 export * from './handle-error';
 export * from './permissions';
+export * from './api-response';


### PR DESCRIPTION
## Summary
S3.7 W4 — 3 architecture cleanups from QA browser E2E v0.2.4.

- **B9** Article URLs ahora usan UUID en lugar de nombres con espacios. `inventory-valuation-widget.linkFor()` usa `item.id`. Article-detail fallback `getById()` cuando `getBySku()` 404 (backwards compat).
- **B17** Helper `unwrapApiResponseList<T>()` normaliza 5 shapes reales del backend (array, items wrapper, data wrapper, null, bare). Frontend-only, opt-in.
- **B18** `/billing` route redirige a `/settings/billing` (BillingPageComponent real ya existía desde S3-W6-B con plan + Stripe portal + checkout + comparison table).

## Validation gates (MSSO v2.3) — 4/4 ✅
- 0 merge markers
- ng build prod clean (1.07 MB initial)
- npm test:ci 980/980 (22 nuevos: 3 widget B9 + 2 article-detail + 15 adapter + 3 routes)
- git status clean

## Test plan
- [ ] CI passes
- [ ] Smoke real chrome — click article from dashboard, URL es UUID
- [ ] /billing redirige a /settings/billing