### PR TITLE
feat(s3.7-w3): SaaS first-touch refinement (B11 i18n + B12 nav + B14 drafts + B23 SeedFarma opt-in)

### DIFF
--- a/src/app/components/layout/sidebar/sidebar.component.spec.ts
+++ b/src/app/components/layout/sidebar/sidebar.component.spec.ts
@@ -80,3 +80,70 @@ describe('SidebarComponent — S3.7 W1 mobile responsive', () => {
     expect(drawer.className).toContain('md:translate-x-0');
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────
+// S3.7 W3 (B11 + B12) — sidebar items + section headings resolve to Spanish.
+// Uses the real LanguageService (with the actual translation tables) so we
+// can assert that bare nav keys actually resolve to the expected strings.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('SidebarComponent — S3.7 W3 i18n keys (B11 + B12)', () => {
+  class StubNavigationServiceB11 {
+    getItems() {
+      return [
+        { name: 'receiving_tasks', href: '/receiving-tasks', icon: 'Download' } as any,
+        { name: 'picking_tasks', href: '/picking-tasks', icon: 'ClipboardCheck' } as any,
+        { name: 'stock_adjustments', href: '/stock-adjustments', icon: 'Edit' } as any,
+        { name: 'categories', href: '/categories', icon: 'FolderTree' } as any,
+        { name: 'inventory', href: '/inventory', icon: 'Archive' } as any,
+        { name: 'clients', href: '/clients', icon: 'Building' } as any,
+      ];
+    }
+  }
+
+  let language: LanguageService;
+
+  beforeEach(async () => {
+    // Force ES locale before instantiation to keep the assertion stable.
+    localStorage.setItem('estock-language', 'es');
+
+    await TestBed.configureTestingModule({
+      imports: [SidebarComponent],
+      providers: [
+        provideRouter([]),
+        SidebarService,
+        LanguageService,
+        { provide: NavigationService, useClass: StubNavigationServiceB11 },
+      ],
+    }).compileComponents();
+
+    language = TestBed.inject(LanguageService);
+    language.setLanguage('es');
+    const fix = TestBed.createComponent(SidebarComponent);
+    fix.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('estock-language');
+  });
+
+  it('B12: bare "categories" nav key resolves to "Categorías" (Title Case)', () => {
+    expect(language.t('categories')).toBe('Categorías');
+  });
+
+  it('B11: nav item keys resolve to Spanish (no English leakage)', () => {
+    expect(language.t('receiving_tasks')).toBe('Tareas de Recepción');
+    expect(language.t('picking_tasks')).toBe('Tareas de Picking');
+    expect(language.t('stock_adjustments')).toBe('Ajustes de Stock');
+    expect(language.t('inventory')).toBe('Inventario');
+    expect(language.t('clients')).toBe('Clientes');
+    expect(language.t('articles')).toBe('Artículos');
+  });
+
+  it('B11: sidebar section heading keys resolve to Spanish', () => {
+    expect(language.t('sidebar.section.operations')).toBe('Operaciones');
+    expect(language.t('sidebar.section.inventory')).toBe('Inventario');
+    expect(language.t('sidebar.section.administration')).toBe('Administración');
+    expect(language.t('sidebar.section.overview')).toBe('Resumen');
+  });
+});

--- a/src/app/components/picking-tasks/picking-task-management/picking-task-management.component.html
+++ b/src/app/components/picking-tasks/picking-task-management/picking-task-management.component.html
@@ -73,13 +73,19 @@
   <!-- Tabs card -->
   <div class="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
 
-    <!-- Tab nav -->
+    <!-- Tab nav — S3.7 W3 (B14): added Drafts tab so draft-status tasks are visible -->
     <div class="border-b border-border">
       <nav class="flex">
         <button (click)="setActiveTab('active')" [class]="getTabClass('active')"
           class="flex flex-1 items-center justify-center min-w-0">
           <span class="truncate">{{ t('active_tasks') }}</span>
           <span [class]="getTabBadgeClass('active')">{{ activeTasks.length }}</span>
+        </button>
+        <button (click)="setActiveTab('drafts')" [class]="getTabClass('drafts')"
+          data-testid="tab-drafts"
+          class="flex flex-1 items-center justify-center min-w-0">
+          <span class="truncate">{{ t('drafts') }}</span>
+          <span [class]="getTabBadgeClass('drafts')">{{ draftTasks.length }}</span>
         </button>
         <button (click)="setActiveTab('processed')" [class]="getTabClass('processed')"
           class="flex flex-1 items-center justify-center min-w-0">
@@ -103,7 +109,7 @@
         />
       </div>
       <span class="shrink-0 text-xs text-muted-foreground tabular-nums">
-        {{ currentTabTasks.length }} {{ t('of') }} {{ (activeTab === 'active' ? activeTasks : processedTasks).length }} {{ t('results') }}
+        {{ currentTabTasks.length }} {{ t('of') }} {{ currentTabBaseTotal }} {{ t('results') }}
       </span>
     </div>
 

--- a/src/app/components/picking-tasks/picking-task-management/picking-task-management.component.spec.ts
+++ b/src/app/components/picking-tasks/picking-task-management/picking-task-management.component.spec.ts
@@ -1,0 +1,100 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PickingTaskManagementComponent } from './picking-task-management.component';
+import { PickingTaskService } from '@app/services/picking-task.service';
+import { AlertService } from '@app/services/extras/alert.service';
+import { LanguageService } from '@app/services/extras/language.service';
+import { LoadingService } from '@app/services/extras/loading.service';
+import { ZardDialogService } from '@app/shared/components/dialog';
+import { mockResponse } from '../../../../__tests__/mocks/data';
+
+describe('PickingTaskManagementComponent (S3.7 W3 B14)', () => {
+  let component: PickingTaskManagementComponent;
+  let fixture: ComponentFixture<PickingTaskManagementComponent>;
+  let serviceSpy: jasmine.SpyObj<PickingTaskService>;
+
+  const langSpy = jasmine.createSpyObj('LanguageService', ['t']);
+  const alertSpy = jasmine.createSpyObj('AlertService', ['success', 'error', 'info']);
+  const loadingSpy = jasmine.createSpyObj('LoadingService', ['show', 'hide']);
+  const dialogSpy = jasmine.createSpyObj('ZardDialogService', ['create']);
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('PickingTaskService', ['getAll']);
+    langSpy.t.and.callFake((key: string) => key);
+
+    await TestBed.configureTestingModule({
+      imports: [PickingTaskManagementComponent, HttpClientTestingModule, RouterModule.forRoot([])],
+      providers: [
+        { provide: PickingTaskService, useValue: serviceSpy },
+        { provide: AlertService, useValue: alertSpy },
+        { provide: LanguageService, useValue: langSpy },
+        { provide: LoadingService, useValue: loadingSpy },
+        { provide: ZardDialogService, useValue: dialogSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PickingTaskManagementComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('B14 S3.7 W3: drafts tab', () => {
+    it('exposes draftTasks separated from active and processed', fakeAsync(async () => {
+      serviceSpy.getAll.and.returnValue(
+        Promise.resolve(
+          mockResponse([
+            { task_id: 'p-1', status: 'open', priority: 'normal' },
+            { task_id: 'p-2', status: 'in_progress', priority: 'normal' },
+            { task_id: 'p-3', status: 'completed', priority: 'normal' },
+            { task_id: 'p-4', status: 'draft', priority: 'normal' },
+            { task_id: 'p-5', status: 'draft', priority: 'normal' },
+            { task_id: 'p-6', status: 'draft', priority: 'normal' },
+          ] as any),
+        ),
+      );
+
+      fixture.detectChanges();
+      await Promise.resolve();
+      tick();
+
+      expect(component.draftTasks.length).toBe(3);
+      expect(component.activeTasks.length).toBe(2);
+      expect(component.processedTasks.length).toBe(1);
+    }));
+
+    it('switches currentTabTasks to drafts when activeTab is "drafts"', fakeAsync(async () => {
+      serviceSpy.getAll.and.returnValue(
+        Promise.resolve(
+          mockResponse([
+            { task_id: 'p-1', status: 'open', priority: 'normal' },
+            { task_id: 'p-4', status: 'draft', priority: 'normal' },
+          ] as any),
+        ),
+      );
+
+      fixture.detectChanges();
+      await Promise.resolve();
+      tick();
+
+      component.setActiveTab('drafts');
+      expect(component.activeTab).toBe('drafts');
+      expect(component.currentTabTasks.length).toBe(1);
+      expect(component.currentTabTasks[0].task_id).toBe('p-4');
+      expect(component.currentTabBaseTotal).toBe(1);
+      expect(component.currentTabDescription).toBe('tasks_in_draft');
+    }));
+
+    it('renders the drafts tab button in the template', fakeAsync(async () => {
+      serviceSpy.getAll.and.returnValue(Promise.resolve(mockResponse([] as any)));
+      fixture.detectChanges();
+      await Promise.resolve();
+      tick();
+      fixture.detectChanges();
+
+      const draftsTab = fixture.nativeElement.querySelector(
+        '[data-testid="tab-drafts"]',
+      ) as HTMLButtonElement | null;
+      expect(draftsTab).not.toBeNull();
+    }));
+  });
+});

--- a/src/app/components/picking-tasks/picking-task-management/picking-task-management.component.ts
+++ b/src/app/components/picking-tasks/picking-task-management/picking-task-management.component.ts
@@ -38,7 +38,9 @@ export class PickingTaskManagementComponent implements OnInit {
   isCreateDialogOpen = false;
   isEditDialogOpen = false;
   editingTask: PickingTask | null = null;
-  activeTab: 'active' | 'processed' = 'active';
+  // S3.7 W3 (B14) — added 'drafts' tab to surface draft-status tasks that were
+  // previously invisible (only active/processed buckets existed).
+  activeTab: 'active' | 'processed' | 'drafts' = 'active';
   searchQuery = '';
 
   // Export configuration
@@ -81,11 +83,11 @@ export class PickingTaskManagementComponent implements OnInit {
     return this.languageService.t.bind(this.languageService);
   }
 
-  setActiveTab(tab: 'active' | 'processed'): void {
+  setActiveTab(tab: 'active' | 'processed' | 'drafts'): void {
     this.activeTab = tab;
   }
 
-  getTabClass(tab: 'active' | 'processed'): string {
+  getTabClass(tab: 'active' | 'processed' | 'drafts'): string {
     const isActive = this.activeTab === tab;
     const baseClasses =
       'py-3 px-4 border-b-2 font-medium text-sm transition-all duration-200 cursor-pointer';
@@ -97,7 +99,7 @@ export class PickingTaskManagementComponent implements OnInit {
     }
   }
 
-  getTabBadgeClass(tab: 'active' | 'processed'): string {
+  getTabBadgeClass(tab: 'active' | 'processed' | 'drafts'): string {
     const isActive = this.activeTab === tab;
     const baseClasses = 'ml-2 text-xs px-2.5 py-1 rounded-full font-medium';
 
@@ -145,8 +147,18 @@ export class PickingTaskManagementComponent implements OnInit {
     );
   }
 
+  // S3.7 W3 (B14) — drafts surface tasks with status === 'draft' so they
+  // are not invisible in the UI.
+  get draftTasks(): PickingTask[] {
+    return this.pickingTasks.filter((task) => task.status === 'draft');
+  }
+
   get currentTabTasks(): PickingTask[] {
-    const base = this.activeTab === 'active' ? this.activeTasks : this.processedTasks;
+    let base: PickingTask[];
+    if (this.activeTab === 'active') base = this.activeTasks;
+    else if (this.activeTab === 'drafts') base = this.draftTasks;
+    else base = this.processedTasks;
+
     if (!this.searchQuery.trim()) return base;
     const q = this.searchQuery.toLowerCase();
     return base.filter(t =>
@@ -156,9 +168,15 @@ export class PickingTaskManagementComponent implements OnInit {
   }
 
   get currentTabDescription(): string {
-    return this.activeTab === 'active'
-      ? this.t('tasks_open_or_in_progress')
-      : this.t('tasks_completed_or_cancelled');
+    if (this.activeTab === 'active') return this.t('tasks_open_or_in_progress');
+    if (this.activeTab === 'drafts') return this.t('tasks_in_draft');
+    return this.t('tasks_completed_or_cancelled');
+  }
+
+  get currentTabBaseTotal(): number {
+    if (this.activeTab === 'active') return this.activeTasks.length;
+    if (this.activeTab === 'drafts') return this.draftTasks.length;
+    return this.processedTasks.length;
   }
 
   get openTasksCount(): number {

--- a/src/app/components/receiving-tasks/receiving-task-management/receiving-task-management.component.html
+++ b/src/app/components/receiving-tasks/receiving-task-management/receiving-task-management.component.html
@@ -73,13 +73,19 @@
   <!-- Tabs card -->
   <div class="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
 
-    <!-- Tab nav -->
+    <!-- Tab nav — S3.7 W3 (B14): added Drafts tab so draft-status tasks are visible -->
     <div class="border-b border-border">
       <nav class="flex">
         <button (click)="setActiveTab('active')" [class]="getTabClass('active')"
           class="flex flex-1 items-center justify-center min-w-0">
           <span class="truncate">{{ t('active_tasks') }}</span>
           <span [class]="getTabBadgeClass('active')">{{ activeTasks.length }}</span>
+        </button>
+        <button (click)="setActiveTab('drafts')" [class]="getTabClass('drafts')"
+          data-testid="tab-drafts"
+          class="flex flex-1 items-center justify-center min-w-0">
+          <span class="truncate">{{ t('drafts') }}</span>
+          <span [class]="getTabBadgeClass('drafts')">{{ draftTasks.length }}</span>
         </button>
         <button (click)="setActiveTab('processed')" [class]="getTabClass('processed')"
           class="flex flex-1 items-center justify-center min-w-0">
@@ -103,7 +109,7 @@
         />
       </div>
       <span class="shrink-0 text-xs text-muted-foreground tabular-nums">
-        {{ currentTabTasks.length }} {{ t('of') }} {{ (activeTab === 'active' ? activeTasks : processedTasks).length }} {{ t('results') }}
+        {{ currentTabTasks.length }} {{ t('of') }} {{ currentTabBaseTotal }} {{ t('results') }}
       </span>
     </div>
 

--- a/src/app/components/receiving-tasks/receiving-task-management/receiving-task-management.component.spec.ts
+++ b/src/app/components/receiving-tasks/receiving-task-management/receiving-task-management.component.spec.ts
@@ -56,4 +56,67 @@ describe('ReceivingTaskManagementComponent (B13 S3.6)', () => {
     expect(component.inProgressCount).toBe(1);
     expect(component.activeTasks.length).toBe(2);
   }));
+
+  // ──────────────────────────────────────────────────────────────────────
+  // S3.7 W3 (B14) — Drafts tab surfaces tasks with status === 'draft'
+  // Previously these were invisible (only active/processed buckets existed).
+  // ──────────────────────────────────────────────────────────────────────
+  describe('B14 S3.7 W3: drafts tab', () => {
+    it('exposes draftTasks separated from active and processed', fakeAsync(async () => {
+      serviceSpy.getAll.and.returnValue(
+        Promise.resolve(
+          mockResponse([
+            { task_id: 't-1', status: 'open', priority: 'normal' },
+            { task_id: 't-2', status: 'in_progress', priority: 'normal' },
+            { task_id: 't-3', status: 'completed', priority: 'normal' },
+            { task_id: 't-4', status: 'draft', priority: 'normal' },
+            { task_id: 't-5', status: 'draft', priority: 'normal' },
+          ] as any),
+        ),
+      );
+
+      fixture.detectChanges();
+      await Promise.resolve();
+      tick();
+
+      expect(component.draftTasks.length).toBe(2);
+      expect(component.activeTasks.length).toBe(2); // open + in_progress (not draft)
+      expect(component.processedTasks.length).toBe(1); // completed only
+    }));
+
+    it('switches currentTabTasks to drafts when activeTab is "drafts"', fakeAsync(async () => {
+      serviceSpy.getAll.and.returnValue(
+        Promise.resolve(
+          mockResponse([
+            { task_id: 't-1', status: 'open', priority: 'normal' },
+            { task_id: 't-4', status: 'draft', priority: 'normal' },
+          ] as any),
+        ),
+      );
+
+      fixture.detectChanges();
+      await Promise.resolve();
+      tick();
+
+      component.setActiveTab('drafts');
+      expect(component.activeTab).toBe('drafts');
+      expect(component.currentTabTasks.length).toBe(1);
+      expect(component.currentTabTasks[0].task_id).toBe('t-4');
+      expect(component.currentTabBaseTotal).toBe(1);
+      expect(component.currentTabDescription).toBe('tasks_in_draft');
+    }));
+
+    it('renders the drafts tab button in the template', fakeAsync(async () => {
+      serviceSpy.getAll.and.returnValue(Promise.resolve(mockResponse([] as any)));
+      fixture.detectChanges();
+      await Promise.resolve();
+      tick();
+      fixture.detectChanges();
+
+      const draftsTab = fixture.nativeElement.querySelector(
+        '[data-testid="tab-drafts"]',
+      ) as HTMLButtonElement | null;
+      expect(draftsTab).not.toBeNull();
+    }));
+  });
 });

--- a/src/app/components/receiving-tasks/receiving-task-management/receiving-task-management.component.ts
+++ b/src/app/components/receiving-tasks/receiving-task-management/receiving-task-management.component.ts
@@ -37,7 +37,10 @@ export class ReceivingTaskManagementComponent implements OnInit {
 	isCreateDialogOpen = false;
 	isEditDialogOpen = false;
 	editingTask: ReceivingTask | null = null;
-	activeTab: 'active' | 'processed' = 'active';
+	// S3.7 W3 (B14) — added 'drafts' tab so draft tasks are visible (5 invisible
+	// drafts were previously hidden because the filter only checked open/in_progress
+	// for active and completed*/cancelled for processed).
+	activeTab: 'active' | 'processed' | 'drafts' = 'active';
 	searchQuery = '';
 
 	// Export configuration
@@ -73,11 +76,11 @@ export class ReceivingTaskManagementComponent implements OnInit {
 		return this.languageService.t.bind(this.languageService);
 	}
 
-	setActiveTab(tab: 'active' | 'processed'): void {
+	setActiveTab(tab: 'active' | 'processed' | 'drafts'): void {
 		this.activeTab = tab;
 	}
 
-	getTabClass(tab: 'active' | 'processed'): string {
+	getTabClass(tab: 'active' | 'processed' | 'drafts'): string {
 		const isActive = this.activeTab === tab;
 		const baseClasses = 'py-3 px-4 border-b-2 font-medium text-sm transition-all duration-200 cursor-pointer';
 		
@@ -88,7 +91,7 @@ export class ReceivingTaskManagementComponent implements OnInit {
 		}
 	}
 
-	getTabBadgeClass(tab: 'active' | 'processed'): string {
+	getTabBadgeClass(tab: 'active' | 'processed' | 'drafts'): string {
 		const isActive = this.activeTab === tab;
 		const baseClasses = 'ml-2 text-xs px-2.5 py-1 rounded-full font-medium';
 		
@@ -123,7 +126,7 @@ export class ReceivingTaskManagementComponent implements OnInit {
 	}
 
 	get activeTasks(): ReceivingTask[] {
-		return this.receivingTasks.filter(task => 
+		return this.receivingTasks.filter(task =>
 			task.status === 'open' || task.status === 'in_progress'
 		);
 	}
@@ -136,8 +139,19 @@ export class ReceivingTaskManagementComponent implements OnInit {
 		);
 	}
 
+	// S3.7 W3 (B14) — drafts surface tasks that don't fit active/processed buckets
+	// (e.g. backend status === 'draft' from incomplete creation flows). Without this
+	// tab, draft tasks were invisible in the UI but still consumed DB rows.
+	get draftTasks(): ReceivingTask[] {
+		return this.receivingTasks.filter(task => task.status === 'draft');
+	}
+
 	get currentTabTasks(): ReceivingTask[] {
-		const base = this.activeTab === 'active' ? this.activeTasks : this.processedTasks;
+		let base: ReceivingTask[];
+		if (this.activeTab === 'active') base = this.activeTasks;
+		else if (this.activeTab === 'drafts') base = this.draftTasks;
+		else base = this.processedTasks;
+
 		if (!this.searchQuery.trim()) return base;
 		const q = this.searchQuery.toLowerCase();
 		return base.filter(t =>
@@ -147,9 +161,15 @@ export class ReceivingTaskManagementComponent implements OnInit {
 	}
 
 	get currentTabDescription(): string {
-		return this.activeTab === 'active'
-			? this.t('tasks_open_or_in_progress')
-			: this.t('tasks_completed_or_cancelled');
+		if (this.activeTab === 'active') return this.t('tasks_open_or_in_progress');
+		if (this.activeTab === 'drafts') return this.t('tasks_in_draft');
+		return this.t('tasks_completed_or_cancelled');
+	}
+
+	get currentTabBaseTotal(): number {
+		if (this.activeTab === 'active') return this.activeTasks.length;
+		if (this.activeTab === 'drafts') return this.draftTasks.length;
+		return this.processedTasks.length;
 	}
 
 	get openTasksCount(): number {

--- a/src/app/components/signup/signup/signup.component.html
+++ b/src/app/components/signup/signup/signup.component.html
@@ -183,6 +183,22 @@
               </div>
             </div>
 
+            <!-- B23 S3.7 W3 — Seed demo data opt-in -->
+            <div class="rounded-lg border border-border bg-muted/30 p-3">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  formControlName="seed_demo_data"
+                  data-testid="seed-demo-data-checkbox"
+                  class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-primary cursor-pointer"
+                />
+                <span class="flex-1 text-sm">
+                  <span class="font-medium text-foreground block">{{ t('signup.seed_demo_data_label') }}</span>
+                  <span class="text-xs text-muted-foreground block mt-0.5">{{ t('signup.seed_demo_data_hint') }}</span>
+                </span>
+              </label>
+            </div>
+
             <!-- Submit -->
             <button
               type="submit"

--- a/src/app/components/signup/signup/signup.component.spec.ts
+++ b/src/app/components/signup/signup/signup.component.spec.ts
@@ -108,6 +108,7 @@ describe('SignupComponent', () => {
       admin_name: 'Admin User',
       admin_password: 'SecurePass123!',
       admin_password_confirm: 'SecurePass123!',
+      seed_demo_data: false,
     });
 
     await component.onSubmit();
@@ -130,6 +131,7 @@ describe('SignupComponent', () => {
       admin_name: 'Admin User',
       admin_password: 'SecurePass123!',
       admin_password_confirm: 'SecurePass123!',
+      seed_demo_data: false,
     });
 
     await component.onSubmit();
@@ -153,6 +155,7 @@ describe('SignupComponent', () => {
       admin_name: 'Admin User',
       admin_password: 'SecurePass123!',
       admin_password_confirm: 'SecurePass123!',
+      seed_demo_data: false,
     });
 
     await component.onSubmit();
@@ -170,11 +173,72 @@ describe('SignupComponent', () => {
       admin_name: 'Admin User',
       admin_password: 'SecurePass123!',
       admin_password_confirm: 'SecurePass123!',
+      seed_demo_data: false,
     });
 
     await component.onSubmit();
 
     expect(alertSpy.error).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // S3.7 W3 (B23) — seed_demo_data opt-in checkbox
+  // ──────────────────────────────────────────────────────────────────────
+  describe('B23 S3.7 W3: seed_demo_data opt-in', () => {
+    it('renders the seed_demo_data checkbox', () => {
+      const checkbox = fixture.nativeElement.querySelector(
+        '[data-testid="seed-demo-data-checkbox"]',
+      ) as HTMLInputElement | null;
+      expect(checkbox).not.toBeNull();
+      expect(checkbox?.type).toBe('checkbox');
+    });
+
+    it('seed_demo_data defaults to false (clean signup)', () => {
+      expect(component.form.get('seed_demo_data')?.value).toBeFalse();
+    });
+
+    it('forwards seed_demo_data=true in payload when user opts in', async () => {
+      signupSpy.initiateSignup.and.returnValue(
+        Promise.resolve(mockResponse({ message: 'OK' })),
+      );
+      component.form.setValue({
+        email: 'admin@acme.com',
+        company_name: 'ACME Corp',
+        tenant_slug: 'acme-corp',
+        admin_name: 'Admin User',
+        admin_password: 'SecurePass123!',
+        admin_password_confirm: 'SecurePass123!',
+        seed_demo_data: true,
+      });
+
+      await component.onSubmit();
+
+      expect(signupSpy.initiateSignup).toHaveBeenCalledTimes(1);
+      const payload = signupSpy.initiateSignup.calls.mostRecent().args[0];
+      expect(payload.seed_demo_data).toBeTrue();
+      // password_confirm must NOT leak into the request payload
+      expect((payload as any).admin_password_confirm).toBeUndefined();
+    });
+
+    it('forwards seed_demo_data=false in payload when user keeps default off', async () => {
+      signupSpy.initiateSignup.and.returnValue(
+        Promise.resolve(mockResponse({ message: 'OK' })),
+      );
+      component.form.setValue({
+        email: 'admin@acme.com',
+        company_name: 'ACME Corp',
+        tenant_slug: 'acme-corp',
+        admin_name: 'Admin User',
+        admin_password: 'SecurePass123!',
+        admin_password_confirm: 'SecurePass123!',
+        seed_demo_data: false,
+      });
+
+      await component.onSubmit();
+
+      const payload = signupSpy.initiateSignup.calls.mostRecent().args[0];
+      expect(payload.seed_demo_data).toBeFalse();
+    });
   });
 });

--- a/src/app/components/signup/signup/signup.component.ts
+++ b/src/app/components/signup/signup/signup.component.ts
@@ -52,6 +52,9 @@ export class SignupComponent implements OnInit {
         admin_name: ['', [Validators.required, Validators.minLength(2)]],
         admin_password: ['', [Validators.required, Validators.minLength(8)]],
         admin_password_confirm: ['', [Validators.required]],
+        // S3.7 W3 (B23): default OFF so new tenants start with a clean account.
+        // User must explicitly opt-in to receive demo/sample data on first run.
+        seed_demo_data: [false],
       },
       { validators: passwordMatchValidator },
     );

--- a/src/app/services/signup.service.ts
+++ b/src/app/services/signup.service.ts
@@ -10,6 +10,13 @@ export interface SignupRequest {
   tenant_slug: string;
   admin_name: string;
   admin_password: string;
+  // S3.7 W3 (B23): opt-in flag to load demo/sample data on tenant provisioning.
+  // Default false on the frontend so new tenants start clean unless the user
+  // explicitly checks the "load sample data" box on signup.
+  // NOTE: backend handling (conditional SeedFarma run inside SignupRepository.VerifySignup)
+  // is deferred to S3.7 backend-companion sprint. Frontend forwards the flag so
+  // the backend can act on it once the column lands.
+  seed_demo_data?: boolean;
 }
 
 export interface SignupVerifyResponse {

--- a/src/app/translations/en.ts
+++ b/src/app/translations/en.ts
@@ -100,6 +100,7 @@ export const enTranslations = {
   // Navigation items
   dashboard: 'Dashboard',
   articles: 'Master of SKUs',
+  categories: 'Categories',
   inventory: 'Inventory',
   receiving_tasks: 'Receiving Tasks',
   picking_tasks: 'Picking Tasks',
@@ -991,6 +992,9 @@ export const enTranslations = {
   receiving_task: 'Receiving Task',
   create_task: 'Create Task',
   processed_tasks: 'Processed Tasks',
+  // S3.7 W3 (B14) — Drafts tab + description for receiving + picking management
+  drafts: 'Drafts',
+  tasks_in_draft: 'Tasks in draft state',
   tasks_open_or_in_progress: 'Tasks that are open or in progress',
   tasks_completed_or_cancelled: 'Tasks completed or cancelled',
   no_tasks_found: 'No tasks found',
@@ -2154,6 +2158,9 @@ export const enTranslations = {
   'signup.creating': 'Creating account…',
   'signup.already_have_account': 'Already have an account?',
   'signup.trial_info': 'Free 14-day trial · No credit card required · Cancel anytime',
+  // S3.7 W3 (B23) — seed demo data opt-in
+  'signup.seed_demo_data_label': 'Load sample data to explore the app',
+  'signup.seed_demo_data_hint': 'Recommended for demo. Includes example SKUs, locations and tasks. You can remove them later from settings.',
   'signup.feature_trial': '14-day free trial',
   'signup.feature_trial_desc': 'Full access to all WMS features with no commitment',
   'signup.feature_setup': 'Ready in minutes',

--- a/src/app/translations/es.ts
+++ b/src/app/translations/es.ts
@@ -110,6 +110,7 @@ export const esTranslations = {
   // Navigation items
   dashboard: 'Dashboard',
   articles: 'Artículos',
+  categories: 'Categorías',
   inventory: 'Inventario',
   receiving_tasks: 'Tareas de Recepción',
   picking_tasks: 'Tareas de Picking',
@@ -1034,6 +1035,9 @@ export const esTranslations = {
   receiving_task: 'Tarea de Recepción',
   create_task: 'Crear Tarea',
   processed_tasks: 'Tareas Procesadas',
+  // S3.7 W3 (B14) — Drafts tab + description for receiving + picking management
+  drafts: 'Borradores',
+  tasks_in_draft: 'Tareas en estado borrador',
   tasks_open_or_in_progress: 'Tareas que están abiertas o en progreso',
   tasks_completed_or_cancelled: 'Tareas completadas o canceladas',
   no_tasks_found: 'No se encontraron tareas',
@@ -2281,6 +2285,9 @@ export const esTranslations = {
   'signup.creating': 'Creando cuenta…',
   'signup.already_have_account': '¿Ya tenés cuenta?',
   'signup.trial_info': 'Prueba gratuita 14 días · Sin tarjeta de crédito · Cancelá cuando quieras',
+  // S3.7 W3 (B23) — seed demo data opt-in
+  'signup.seed_demo_data_label': 'Cargar datos de muestra para explorar la app',
+  'signup.seed_demo_data_hint': 'Recomendado para demo. Incluye SKUs, ubicaciones y tareas de ejemplo. Podés borrarlos después desde la configuración.',
   'signup.feature_trial': 'Prueba gratuita 14 días',
   'signup.feature_trial_desc': 'Acceso completo a todas las funciones sin compromiso',
   'signup.feature_setup': 'Listo en minutos',


### PR DESCRIPTION
## Summary

Four QA findings from the S3.7 first-touch SaaS UX review:

- **B11** — Sidebar nav items + section headings already use i18n keys via `LanguageService.t()`; ES translations were already present in `es.ts`. No additional English-leakage source found beyond B12 below. Added a sidebar spec that locks in the ES strings via the real `LanguageService` so any future regression (e.g. an EN-only key sneaking into the nav) is caught immediately.
- **B12** — The bare `categories` translation key was missing in both `es.ts` and `en.ts`, so the sidebar fell back to the literal lowercase key. Added `categories: 'Categorías'` (es) and `categories: 'Categories'` (en); the nav now renders Title Case alongside its siblings.
- **B14** — Receiving + picking management pages only had Active/Processed tabs, leaving `draft`-status tasks invisible (e.g. 5 drafts hidden when DB had 20 but UI showed 15). Added a **Drafts** tab in both managements with its own count badge, `draftTasks` accessor, description string, and i18n keys (`drafts`, `tasks_in_draft`).
- **B23** — `SeedFarma` demo data was loaded by default for every new tenant, contaminating real-customer accounts. Added an opt-in checkbox on the signup form (**default OFF / clean signup**) plus a new `seed_demo_data` boolean on `SignupRequest`. The frontend forwards the flag in the POST `/api/signup` payload.
  - **Backend handling deferred** to the S3.7-backend-companion sprint: `SignupRepository.VerifySignup` should read the flag (likely from a new column on the signup token) and only run `SeedFarma` when `seed_demo_data === true`. The frontend is ready as soon as the backend lands the column.

## Files touched

- `src/app/translations/{es,en}.ts` — bare `categories`, `drafts`, `tasks_in_draft`, `signup.seed_demo_data_label`, `signup.seed_demo_data_hint`
- `src/app/components/receiving-tasks/receiving-task-management/*` — Drafts tab + `draftTasks` getter + spec
- `src/app/components/picking-tasks/picking-task-management/*` — Drafts tab + `draftTasks` getter + new spec file
- `src/app/components/signup/signup/*` — `seed_demo_data` checkbox + form control + spec coverage (default false, opt-in true, payload forwarding)
- `src/app/services/signup.service.ts` — `seed_demo_data?: boolean` on `SignupRequest`
- `src/app/components/layout/sidebar/sidebar.component.spec.ts` — i18n key resolution suite (B11 + B12 regression guard)

## Validation gates (MSSO v2.3)

- [x] grep merge-conflict markers: 0
- [x] `ng build` production: clean (only the pre-existing `dijkstrajs` CommonJS warning from `qrcode`)
- [x] `npm run test:ci`: **968 pass** (baseline 955 + 13 new), 0 NEW failures
- [x] `git status`: only the 13 expected files

## Hard limits respected

- Did not touch dashboard (W2 owner)
- Did not touch layout/sidebar core (W1 done) — only added i18n-resolution spec coverage
- PR open only — not merged

## Test plan

- [ ] Run `npm run test:ci` locally → expect 968 pass
- [ ] Run `npm run build -- --configuration=production` → expect clean
- [ ] Manual: visit `/signup` → verify the "Cargar datos de muestra" checkbox renders unchecked by default
- [ ] Manual: visit `/receiving-tasks` and `/picking-tasks` → verify the third **Borradores** tab is visible and counts draft-status rows
- [ ] Manual: switch language to ES → verify sidebar shows "Categorías" (Title Case) instead of `categories`
- [ ] Coordinate S3.7-backend-companion sprint to consume `seed_demo_data` in `SignupRepository.VerifySignup`